### PR TITLE
feat: adiciona endpoint GET /api/v1/products/:id

### DIFF
--- a/src/controllers/products.controller.js
+++ b/src/controllers/products.controller.js
@@ -6,4 +6,16 @@ function listProducts(req, res) {
     res.status(200).json({ products, total: products.length });
 }
 
-module.exports = { listProducts };
+function getProductById(req, res) {
+    const id = Number(req.params.id);
+    if (!Number.isInteger(id) || id <= 0) {
+        return res.status(404).json({ error: 'Produto nao encontrado' });
+    }
+    const product = productsService.getProductById(id);
+    if (!product) {
+        return res.status(404).json({ error: 'Produto nao encontrado' });
+    }
+    res.status(200).json(product);
+}
+
+module.exports = { listProducts, getProductById };

--- a/src/routes/products.routes.js
+++ b/src/routes/products.routes.js
@@ -4,5 +4,6 @@ const productsController = require('../controllers/products.controller');
 const router = express.Router();
 
 router.get('/', productsController.listProducts);
+router.get('/:id', productsController.getProductById);
 
 module.exports = router;

--- a/src/services/products.service.js
+++ b/src/services/products.service.js
@@ -15,4 +15,9 @@ function listProducts({ category } = {}) {
     return all.filter((p) => p.category && p.category.toLowerCase() === normalized);
 }
 
-module.exports = { listProducts };
+function getProductById(id) {
+    const all = loadProducts();
+    return all.find((p) => p.id === id) || null;
+}
+
+module.exports = { listProducts, getProductById };


### PR DESCRIPTION
Implementa a RF-02 (buscar produto por ID).

> Stacked em cima do #20. Quando o #20 mergear, este PR retargeta automaticamente para main.

## Resumo
- Adiciona getProductById em src/services/products.service.js.
- Adiciona handler no controller e rota GET /:id em src/routes/products.routes.js.
- IDs invalidos (nao inteiro, <= 0) e IDs inexistentes retornam 404 com { error: "Produto nao encontrado" }.
- ID existente retorna 200 com o objeto completo do produto (mesmo schema da listagem).

## Criterios de aceitacao
- [x] 200 + objeto do produto quando o ID existe
- [x] 404 quando o ID nao existe
- [x] Body do 200 segue o schema ja definido (id, name, description, category, price, oldPrice, discount, rating, ratingCount, image)

## Test plan
- [x] curl http://localhost:3001/api/v1/products/1 -> 200 com o Echo Dot
- [x] curl http://localhost:3001/api/v1/products/5 -> 200 com Echo Spot
- [x] curl http://localhost:3001/api/v1/products/1763525218805 -> 200 (id grande valido)
- [x] curl http://localhost:3001/api/v1/products/9999 -> 404
- [x] curl http://localhost:3001/api/v1/products/abc -> 404
- [x] curl http://localhost:3001/api/v1/products/0 -> 404
- [x] Regressao: listagem em /api/v1/products continua 200 com 42 produtos