### PR TITLE
feat: adiciona endpoint DELETE /api/v1/cart (limpar carrinho)

### DIFF
--- a/src/controllers/cart.controller.js
+++ b/src/controllers/cart.controller.js
@@ -33,4 +33,9 @@ function removeItem(req, res) {
     res.status(200).json({ message: 'Item removido do carrinho', cart });
 }
 
-module.exports = { updateItemQuantity, removeItem };
+function clearCart(req, res) {
+    const cart = cartService.clearCart(req.userId);
+    res.status(200).json({ message: 'Carrinho limpo', cart });
+}
+
+module.exports = { updateItemQuantity, removeItem, clearCart };

--- a/src/routes/cart.routes.js
+++ b/src/routes/cart.routes.js
@@ -6,5 +6,6 @@ const router = express.Router();
 
 router.put('/items/:itemId', requireAuth, cartController.updateItemQuantity);
 router.delete('/items/:itemId', requireAuth, cartController.removeItem);
+router.delete('/', requireAuth, cartController.clearCart);
 
 module.exports = router;

--- a/src/services/cart.service.js
+++ b/src/services/cart.service.js
@@ -28,4 +28,9 @@ function removeItem(userId, itemId) {
     return summarize(items);
 }
 
-module.exports = { getCart, updateItemQuantity, removeItem };
+function clearCart(userId) {
+    cartRepository.setByUserId(userId, []);
+    return summarize([]);
+}
+
+module.exports = { getCart, updateItemQuantity, removeItem, clearCart };


### PR DESCRIPTION
Implementa a RF-12 (limpar todos os itens do carrinho).

> Stacked em cima do #25. Retargeta automaticamente quando o anterior mergear.

## Resumo
- Adiciona `clearCart` em `src/services/cart.service.js` (persiste array vazio).
- Adiciona handler no controller e rota `DELETE /api/v1/cart` com `requireAuth`.

## Criterios de aceitacao
- [x] 200 OK ao limpar o carrinho
- [x] 401 quando nao autenticado
- [x] Response contem mensagem e carrinho vazio (items: [], itemCount: 0, total: 0)

## Test plan
- [x] sem Authorization -> 401
- [x] com auth -> 200 e cart vazio
- [x] idempotente: chamar 2x seguidas retorna cart vazio nas duas

Closes #12