### PR TITLE
feat: SQLite migration runner + tabelas carts/cart_items (US-19, US-23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,10 @@ Thumbs.db
 # Build
 dist/
 build/
+
+# SQLite
+*.sqlite
+*.sqlite-journal
+*.sqlite-wal
+*.sqlite-shm
+*.db

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "bulbe-energia-api",
       "version": "0.1.0",
       "dependencies": {
+        "better-sqlite3": "^11.10.0",
         "cors": "^2.8.5",
         "express": "^4.19.2",
         "js-yaml": "^4.1.0",
@@ -47,6 +48,57 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -69,6 +121,30 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -114,6 +190,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -177,6 +259,30 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -194,6 +300,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -232,6 +347,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -277,6 +401,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -325,6 +458,12 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -360,6 +499,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -406,6 +551,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -475,10 +626,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -662,10 +839,43 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -675,6 +885,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/object-assign": {
@@ -710,6 +932,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -725,6 +956,33 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -736,6 +994,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -775,6 +1043,35 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/safe-buffer": {
@@ -938,6 +1235,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -945,6 +1287,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/swagger-ui-dist": {
@@ -971,6 +1331,34 @@
         "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -978,6 +1366,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/type-is": {
@@ -1002,6 +1402,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1019,6 +1425,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     }
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,9 +5,11 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "dev": "node --watch src/server.js"
+    "dev": "node --watch src/server.js",
+    "db:migrate": "node src/db/migrate.js"
   },
   "dependencies": {
+    "better-sqlite3": "^11.10.0",
     "cors": "^2.8.5",
     "express": "^4.19.2",
     "js-yaml": "^4.1.0",

--- a/backend/src/db/connection.js
+++ b/backend/src/db/connection.js
@@ -1,0 +1,14 @@
+const path = require('path');
+const fs = require('fs');
+const Database = require('better-sqlite3');
+
+const DB_PATH = process.env.DB_PATH
+    || path.join(__dirname, '..', '..', 'data', 'bulbe.sqlite');
+
+fs.mkdirSync(path.dirname(DB_PATH), { recursive: true });
+
+const db = new Database(DB_PATH);
+db.pragma('journal_mode = WAL');
+db.pragma('foreign_keys = ON');
+
+module.exports = db;

--- a/backend/src/db/migrate.js
+++ b/backend/src/db/migrate.js
@@ -1,0 +1,71 @@
+const fs = require('fs');
+const path = require('path');
+const db = require('./connection');
+
+const MIGRATIONS_DIR = process.env.MIGRATIONS_DIR
+    || path.join(__dirname, 'migrations');
+
+function ensureMigrationsTable() {
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS _migrations (
+            name TEXT PRIMARY KEY,
+            applied_at TEXT NOT NULL DEFAULT (datetime('now'))
+        )
+    `);
+}
+
+function listMigrationFiles() {
+    if (!fs.existsSync(MIGRATIONS_DIR)) return [];
+    return fs
+        .readdirSync(MIGRATIONS_DIR)
+        .filter((f) => f.endsWith('.sql'))
+        .sort();
+}
+
+function appliedMigrations() {
+    const rows = db.prepare('SELECT name FROM _migrations').all();
+    return new Set(rows.map((r) => r.name));
+}
+
+function applyMigration(name) {
+    const sql = fs.readFileSync(path.join(MIGRATIONS_DIR, name), 'utf8');
+    const insert = db.prepare('INSERT INTO _migrations (name) VALUES (?)');
+    const tx = db.transaction(() => {
+        db.exec(sql);
+        insert.run(name);
+    });
+    tx();
+}
+
+function runMigrations() {
+    ensureMigrationsTable();
+    const applied = appliedMigrations();
+    const files = listMigrationFiles();
+    const pending = files.filter((f) => !applied.has(f));
+
+    if (pending.length === 0) {
+        console.log('[migrate] nada para aplicar');
+        return { applied: [] };
+    }
+
+    const appliedNow = [];
+    for (const name of pending) {
+        console.log(`[migrate] aplicando ${name}`);
+        applyMigration(name);
+        appliedNow.push(name);
+    }
+    console.log(`[migrate] ${appliedNow.length} migration(s) aplicada(s)`);
+    return { applied: appliedNow };
+}
+
+if (require.main === module) {
+    try {
+        runMigrations();
+        process.exit(0);
+    } catch (err) {
+        console.error('[migrate] erro:', err.message);
+        process.exit(1);
+    }
+}
+
+module.exports = { runMigrations };

--- a/backend/src/db/migrations/000_init.sql
+++ b/backend/src/db/migrations/000_init.sql
@@ -1,0 +1,1 @@
+PRAGMA foreign_keys = ON;

--- a/backend/src/db/migrations/004_create_carts.sql
+++ b/backend/src/db/migrations/004_create_carts.sql
@@ -1,0 +1,22 @@
+-- Tabelas de carrinho e itens (US-23).
+-- FK para users(id) e products(id) ativa via PRAGMA foreign_keys (definido em connection.js).
+-- Pre-requisito: migrations 001 (users) e 002 (products) ja aplicadas (US-20, US-21).
+
+CREATE TABLE IF NOT EXISTS carts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id INTEGER NOT NULL UNIQUE REFERENCES users(id) ON DELETE CASCADE,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS cart_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    cart_id INTEGER NOT NULL REFERENCES carts(id) ON DELETE CASCADE,
+    product_id INTEGER NOT NULL REFERENCES products(id),
+    quantity INTEGER NOT NULL CHECK (quantity BETWEEN 1 AND 99),
+    unit_price REAL NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE (cart_id, product_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_cart_items_cart ON cart_items(cart_id);

--- a/backend/src/repositories/cart.repository.js
+++ b/backend/src/repositories/cart.repository.js
@@ -1,31 +1,92 @@
-const fs = require('fs');
-const path = require('path');
+const db = require('../db/connection');
+const productsService = require('../services/products.service');
 
-const CARTS_FILE = path.join(__dirname, '..', 'data', 'carts.json');
-
-function loadAll() {
-    if (!fs.existsSync(CARTS_FILE)) return {};
-    const raw = fs.readFileSync(CARTS_FILE, 'utf8');
-    return raw.trim() ? JSON.parse(raw) : {};
+function getCartIdByUserId(userId) {
+    const row = db.prepare('SELECT id FROM carts WHERE user_id = ?').get(userId);
+    return row ? row.id : null;
 }
 
-function saveAll(carts) {
-    fs.writeFileSync(CARTS_FILE, JSON.stringify(carts, null, 2));
+function getOrCreateCartId(userId) {
+    const existing = getCartIdByUserId(userId);
+    if (existing) return existing;
+    const info = db
+        .prepare('INSERT INTO carts (user_id) VALUES (?)')
+        .run(userId);
+    return info.lastInsertRowid;
+}
+
+function hydrate(row) {
+    const product = productsService.getProductById(row.product_id);
+    return {
+        id: row.id,
+        productId: row.product_id,
+        name: product ? product.name : null,
+        price: row.unit_price,
+        oldPrice: product ? product.oldPrice : null,
+        image: product ? product.image : null,
+        rating: product ? product.rating : null,
+        ratingCount: product ? product.ratingCount : null,
+        quantity: row.quantity,
+    };
 }
 
 function getByUserId(userId) {
-    const carts = loadAll();
-    return Array.isArray(carts[userId]) ? carts[userId] : [];
+    const cartId = getCartIdByUserId(userId);
+    if (!cartId) return [];
+    const rows = db
+        .prepare(
+            'SELECT id, product_id, quantity, unit_price FROM cart_items WHERE cart_id = ? ORDER BY id'
+        )
+        .all(cartId);
+    return rows.map(hydrate);
+}
+
+function getTotalByUserId(userId) {
+    const cartId = getCartIdByUserId(userId);
+    if (!cartId) return 0;
+    const row = db
+        .prepare(
+            'SELECT COALESCE(SUM(quantity * unit_price), 0) AS total FROM cart_items WHERE cart_id = ?'
+        )
+        .get(cartId);
+    return row.total;
 }
 
 function setByUserId(userId, items) {
-    const carts = loadAll();
-    if (!items || items.length === 0) {
-        delete carts[userId];
-    } else {
-        carts[userId] = items;
-    }
-    saveAll(carts);
+    const tx = db.transaction(() => {
+        const cartId = getCartIdByUserId(userId);
+
+        if (!items || items.length === 0) {
+            if (cartId) {
+                db.prepare('DELETE FROM cart_items WHERE cart_id = ?').run(cartId);
+                db.prepare('DELETE FROM carts WHERE id = ?').run(cartId);
+            }
+            return;
+        }
+
+        const targetCartId = cartId || getOrCreateCartId(userId);
+        const incomingProductIds = items.map((it) => it.productId);
+        const placeholders = incomingProductIds.map(() => '?').join(',');
+
+        db.prepare(
+            `DELETE FROM cart_items WHERE cart_id = ? AND product_id NOT IN (${placeholders})`
+        ).run(targetCartId, ...incomingProductIds);
+
+        const upsert = db.prepare(`
+            INSERT INTO cart_items (cart_id, product_id, quantity, unit_price)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(cart_id, product_id) DO UPDATE SET
+                quantity = excluded.quantity,
+                unit_price = excluded.unit_price
+        `);
+        for (const it of items) {
+            upsert.run(targetCartId, it.productId, it.quantity, it.price);
+        }
+
+        db.prepare('UPDATE carts SET updated_at = datetime(\'now\') WHERE id = ?')
+            .run(targetCartId);
+    });
+    tx();
 }
 
-module.exports = { getByUserId, setByUserId };
+module.exports = { getByUserId, setByUserId, getTotalByUserId };

--- a/backend/src/services/cart.service.js
+++ b/backend/src/services/cart.service.js
@@ -3,14 +3,14 @@ const productsService = require('./products.service');
 
 const MAX_QUANTITY = 99;
 
-function summarize(items) {
+function summarize(userId, items) {
     const itemCount = items.reduce((sum, it) => sum + it.quantity, 0);
-    const total = items.reduce((sum, it) => sum + it.price * it.quantity, 0);
+    const total = cartRepository.getTotalByUserId(userId);
     return { items, itemCount, total: Number(total.toFixed(2)) };
 }
 
 function getCart(userId) {
-    return summarize(cartRepository.getByUserId(userId));
+    return summarize(userId, cartRepository.getByUserId(userId));
 }
 
 function addItem(userId, productId, quantity) {
@@ -18,11 +18,11 @@ function addItem(userId, productId, quantity) {
     if (!product) return null;
 
     const items = cartRepository.getByUserId(userId);
-    const index = items.findIndex((it) => it.id === productId);
+    const index = items.findIndex((it) => it.productId === productId);
 
     if (index === -1) {
         items.push({
-            id: product.id,
+            productId: product.id,
             name: product.name,
             price: product.price,
             oldPrice: product.oldPrice,
@@ -37,7 +37,7 @@ function addItem(userId, productId, quantity) {
     }
 
     cartRepository.setByUserId(userId, items);
-    return summarize(items);
+    return summarize(userId, cartRepository.getByUserId(userId));
 }
 
 function updateItemQuantity(userId, itemId, quantity) {
@@ -46,7 +46,7 @@ function updateItemQuantity(userId, itemId, quantity) {
     if (index === -1) return null;
     items[index] = { ...items[index], quantity };
     cartRepository.setByUserId(userId, items);
-    return summarize(items);
+    return summarize(userId, cartRepository.getByUserId(userId));
 }
 
 function removeItem(userId, itemId) {
@@ -55,12 +55,12 @@ function removeItem(userId, itemId) {
     if (index === -1) return null;
     items.splice(index, 1);
     cartRepository.setByUserId(userId, items);
-    return summarize(items);
+    return summarize(userId, cartRepository.getByUserId(userId));
 }
 
 function clearCart(userId) {
     cartRepository.setByUserId(userId, []);
-    return summarize([]);
+    return summarize(userId, []);
 }
 
 module.exports = { getCart, addItem, updateItemQuantity, removeItem, clearCart };


### PR DESCRIPTION
## Resumo

Entrega duas user stories de sprint 2 do eixo SQLite:

- **#35 — US-19**: setup mínimo de SQLite (`better-sqlite3`), runner de migrations versionadas e schema inicial.
- **#39 — US-23**: tabelas `carts` + `cart_items` e refator do `cart.repository` pra SQL puro, com total calculado por `SUM` SQL e integridade referencial.

Como nenhuma das migrations de pré-requisito (US-18, US-20, US-21) foi entregue ainda, este PR também adiciona o mínimo de US-18 (`connection.js`) para US-19 ser executável.

## Critérios de Aceitação

### US-19 — Migration runner

- [x] Pasta `backend/src/db/migrations/` criada
- [x] Script `backend/src/db/migrate.js` lê arquivos `NNN_*.sql` em ordem
- [x] Tabela `_migrations` registra o que já rodou (criada pelo próprio runner em `ensureMigrationsTable`)
- [x] Script `npm run db:migrate` no `package.json`
- [x] `000_init.sql` ativa `PRAGMA foreign_keys`
- [x] Idempotente: rodar `npm run db:migrate` duas vezes não dispara nada na segunda

### US-23 — Tabelas carts + cart_items

- [x] `004_create_carts.sql` cria `carts (id, user_id FK→users UNIQUE, created_at, updated_at)` e `cart_items (id, cart_id FK→carts, product_id FK→products, quantity, unit_price, created_at)`
- [x] Constraint: cada `user_id` tem no máximo 1 cart (UNIQUE)
- [x] Constraint: `quantity BETWEEN 1 AND 99` (CHECK)
- [x] `cart.repository.js` refatorado pra SQL mantendo `getByUserId` / `setByUserId`
- [x] Total via SQL: novo `getTotalByUserId(userId)` = `SUM(quantity * unit_price)`
- [x] Endpoints `GET/POST/PUT/DELETE /cart*` respondem o mesmo shape (`items / itemCount / total`)

## Mudança de contrato (heads-up p/ o front)

Com PK separada em `cart_items`, o `itemId` que vai pro `PUT /cart/items/:itemId` e `DELETE /cart/items/:itemId` agora é o `cart_item.id` retornado pelo `GET /cart`, **não mais o `productId`**. Cada item da resposta agora traz `id` (cart_item.id) **e** `productId` separadamente — o front precisa usar `id` pra mutações.

## Dependência pra rodar `004` end-to-end

`004_create_carts.sql` declara FK pra `users(id)` e `products(id)`, que vão ser criadas em **US-20** e **US-21** (issues #36 e #37, não minhas). Sem essas migrations no diretório, a aplicação de `004` falha por tabela inexistente.

Pra ainda assim provar que `004` funciona, o smoke test rodou apontando `MIGRATIONS_DIR` pra um diretório com stubs mínimos de `users` e `products` + o `004` real deste PR, e exercitou o repository completo (add → acumula qty no mesmo produto → update → remove → clear). Detalhes na Test plan.

## Test plan

### US-19 — idempotência do runner

- [x] `rm -f backend/data/bulbe.sqlite*` (limpa state)
- [x] `npm run db:migrate` → aplica `000_init.sql`
- [x] `npm run db:migrate` (de novo) → `[migrate] nada para aplicar`
- [x] `SELECT * FROM _migrations` → 1 linha `000_init.sql` com `applied_at`

### US-23 — repository SQL

Setup: `MIGRATIONS_DIR=/tmp/stubs node src/db/migrate.js` com `/tmp/stubs` = `000_init.sql` + stubs `001_users.sql` (id, email) + `002_products.sql` (id, name, price) + `004_create_carts.sql` deste PR.

- [x] Carrinho vazio → `{items:[], itemCount:0, total:0}`
- [x] `addItem(user=1, prod=1, qty=2)` → total `797.98` (398.99 × 2)
- [x] `addItem(user=1, prod=2, qty=1)` → total `1139.97`
- [x] `addItem(user=1, prod=1, qty=3)` repete produto → UPSERT acumula em 1 linha só com qty=5 (UNIQUE `cart_id, product_id` honrado)
- [x] `updateItemQuantity(user=1, itemId=1, qty=10)` → total `4331.89`
- [x] `removeItem(user=1, itemId=1)` → sobra só o item do prod 2
- [x] `getTotalByUserId(1)` = `341.99` (= SUM SQL)
- [x] `clearCart(1)` → `items:[], total:0` e a row em `carts` é apagada também (cascade)

### Pendente p/ quem mergear

- [ ] Quando US-20/US-21 mergearem, rodar `npm run db:migrate` numa cópia limpa pra confirmar que `004` aplica em sequência com os schemas reais de `users`/`products`.

Closes #35
Closes #39