### PR TITLE
feat(sqlite): migra cupons e pedidos para SQLite (US-22, US-24)

### DIFF
--- a/backend/src/db/migrations/003_create_coupons.sql
+++ b/backend/src/db/migrations/003_create_coupons.sql
@@ -13,3 +13,18 @@ CREATE TABLE IF NOT EXISTS coupons (
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+-- Seed inicial importado de src/data/coupons.json (US-22).
+-- INSERT OR IGNORE mantem a migration idempotente: nao duplica se ja existir.
+-- Todos os cupons atuais sao percentuais e sem expiracao (validade NULL).
+INSERT OR IGNORE INTO coupons (code, discount, type) VALUES
+    ('BULBE10', 0.10, 'percentage'),
+    ('BULBE15', 0.15, 'percentage'),
+    ('BULBE20', 0.20, 'percentage'),
+    ('BLACKFRIDAY', 0.20, 'percentage'),
+    ('WELCOME5', 0.05, 'percentage'),
+    ('PROMO25', 0.25, 'percentage'),
+    ('SUPERPROMO', 0.40, 'percentage'),
+    ('SUPER30', 0.30, 'percentage'),
+    ('CLIENTEVIP', 0.12, 'percentage'),
+    ('MEGASALE', 0.18, 'percentage');

--- a/backend/src/db/migrations/003_create_coupons.sql
+++ b/backend/src/db/migrations/003_create_coupons.sql
@@ -1,0 +1,15 @@
+-- Tabela de cupons de desconto (US-22).
+-- Sem FK: cupons sao entidade independente, identificados pelo proprio codigo.
+-- validade NULL = cupom sem expiracao. A validacao temporal e feita por query
+-- no repositorio (WHERE validade IS NULL OR validade >= date('now')).
+
+CREATE TABLE IF NOT EXISTS coupons (
+    code TEXT PRIMARY KEY,
+    discount REAL NOT NULL CHECK (discount >= 0),
+    type TEXT NOT NULL DEFAULT 'percentage' CHECK (type IN ('percentage', 'fixed')),
+    validade TEXT,
+    max_uses INTEGER,
+    used_count INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/backend/src/db/migrations/005_create_orders.sql
+++ b/backend/src/db/migrations/005_create_orders.sql
@@ -1,0 +1,47 @@
+-- Tabelas de pedidos e itens (US-24).
+-- FK para users(id) e products(id) declaradas; ativas via PRAGMA foreign_keys
+-- (connection.js). Pre-requisito: migrations 001 (users) e 002 (products).
+--
+-- id TEXT (ord-<hex>) preserva o identificador atual exposto pelos endpoints.
+-- user_id e TEXT pois requireAuth injeta o token cru em req.userId (mesmo
+-- comportamento ja adotado em carts). order_items.unit_price_snapshot congela
+-- o preco no momento da compra (nao acompanha alteracoes futuras do produto).
+-- Campos nao normalizaveis do contrato (customer, enderecos) ficam em colunas
+-- JSON para preservar a resposta dos endpoints sem mudanca contratual.
+
+CREATE TABLE IF NOT EXISTS orders (
+    id TEXT PRIMARY KEY,
+    order_code TEXT NOT NULL,
+    user_id TEXT NOT NULL REFERENCES users(id),
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'paid', 'shipped', 'delivered', 'cancelled')),
+    payment_method TEXT NOT NULL,
+    coupon_code TEXT,
+    coupon_discount REAL NOT NULL DEFAULT 0,
+    pix_discount REAL NOT NULL DEFAULT 0,
+    subtotal REAL NOT NULL,
+    shipping REAL NOT NULL,
+    total REAL NOT NULL,
+    final_amount REAL NOT NULL,
+    customer_json TEXT NOT NULL,
+    billing_address_json TEXT NOT NULL,
+    delivery_address_json TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS order_items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    order_id TEXT NOT NULL REFERENCES orders(id) ON DELETE CASCADE,
+    product_id INTEGER NOT NULL REFERENCES products(id),
+    quantity INTEGER NOT NULL CHECK (quantity >= 1),
+    unit_price_snapshot REAL NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Historico de pedidos do usuario, do mais recente para o mais antigo.
+CREATE INDEX IF NOT EXISTS idx_orders_user_created
+    ON orders (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_order_items_order
+    ON order_items (order_id);

--- a/backend/src/repositories/coupon.repository.js
+++ b/backend/src/repositories/coupon.repository.js
@@ -1,18 +1,18 @@
-const fs = require('fs');
-const path = require('path');
+const db = require('../db/connection');
 
-const COUPONS_FILE = path.join(__dirname, '..', 'data', 'coupons.json');
-
-function loadAll() {
-    if (!fs.existsSync(COUPONS_FILE)) return [];
-    const raw = fs.readFileSync(COUPONS_FILE, 'utf8');
-    return raw.trim() ? JSON.parse(raw) : [];
-}
+// Cupom valido = existe E (sem validade OU validade ainda nao expirou).
+// A checagem temporal e feita na query (US-22): validade >= data de hoje.
+const FIND_VALID = db.prepare(`
+    SELECT code, discount, type, validade, max_uses, used_count
+    FROM coupons
+    WHERE code = ?
+      AND (validade IS NULL OR validade >= date('now'))
+`);
 
 function findByCode(code) {
     if (!code) return null;
     const normalized = String(code).trim().toUpperCase();
-    return loadAll().find((c) => c.code === normalized) || null;
+    return FIND_VALID.get(normalized) || null;
 }
 
 module.exports = { findByCode };

--- a/backend/src/repositories/order.repository.js
+++ b/backend/src/repositories/order.repository.js
@@ -1,31 +1,100 @@
-const fs = require('fs');
-const path = require('path');
+const db = require('../db/connection');
 
-const ORDERS_FILE = path.join(__dirname, '..', 'data', 'orders.json');
+const INSERT_ORDER = db.prepare(`
+    INSERT INTO orders (
+        id, order_code, user_id, status, payment_method,
+        coupon_code, coupon_discount, pix_discount,
+        subtotal, shipping, total, final_amount,
+        customer_json, billing_address_json, delivery_address_json, created_at
+    ) VALUES (
+        @id, @orderCode, @customerId, @status, @paymentMethod,
+        @couponCode, @couponDiscount, @pixDiscount,
+        @subtotal, @shipping, @total, @finalAmount,
+        @customerJson, @billingAddressJson, @deliveryAddressJson, @createdAt
+    )
+`);
 
-function loadAll() {
-    if (!fs.existsSync(ORDERS_FILE)) return [];
-    const raw = fs.readFileSync(ORDERS_FILE, 'utf8');
-    return raw.trim() ? JSON.parse(raw) : [];
+const INSERT_ITEM = db.prepare(`
+    INSERT INTO order_items (order_id, product_id, quantity, unit_price_snapshot)
+    VALUES (?, ?, ?, ?)
+`);
+
+const FIND_ORDER = db.prepare('SELECT * FROM orders WHERE id = ?');
+
+const FIND_ORDERS_BY_USER = db.prepare(`
+    SELECT * FROM orders WHERE user_id = ? ORDER BY created_at DESC
+`);
+
+const FIND_ITEMS = db.prepare(`
+    SELECT product_id, quantity, unit_price_snapshot
+    FROM order_items WHERE order_id = ? ORDER BY id
+`);
+
+// Reconstroi o objeto de pedido no mesmo formato exposto pelos endpoints,
+// reidratando os itens e os campos guardados como JSON.
+function hydrate(row) {
+    if (!row) return null;
+    const items = FIND_ITEMS.all(row.id).map((it) => ({
+        id: it.product_id,
+        quantity: it.quantity,
+        price: it.unit_price_snapshot,
+    }));
+    return {
+        id: row.id,
+        orderCode: row.order_code,
+        customerId: row.user_id,
+        items,
+        paymentMethod: row.payment_method,
+        customer: JSON.parse(row.customer_json),
+        billingAddress: JSON.parse(row.billing_address_json),
+        deliveryAddress: JSON.parse(row.delivery_address_json),
+        couponCode: row.coupon_code,
+        subtotal: row.subtotal,
+        shipping: row.shipping,
+        couponDiscount: row.coupon_discount,
+        pixDiscount: row.pix_discount,
+        total: row.total,
+        finalAmount: row.final_amount,
+        createdAt: row.created_at,
+    };
 }
 
-function saveAll(orders) {
-    fs.writeFileSync(ORDERS_FILE, JSON.stringify(orders, null, 2));
-}
+// Grava pedido e itens atomicamente: ou tudo, ou nada.
+const insertTx = db.transaction((order) => {
+    INSERT_ORDER.run({
+        id: order.id,
+        orderCode: order.orderCode,
+        customerId: order.customerId,
+        status: order.status || 'pending',
+        paymentMethod: order.paymentMethod,
+        couponCode: order.couponCode,
+        couponDiscount: order.couponDiscount,
+        pixDiscount: order.pixDiscount,
+        subtotal: order.subtotal,
+        shipping: order.shipping,
+        total: order.total,
+        finalAmount: order.finalAmount,
+        customerJson: JSON.stringify(order.customer),
+        billingAddressJson: JSON.stringify(order.billingAddress),
+        deliveryAddressJson: JSON.stringify(order.deliveryAddress),
+        createdAt: order.createdAt,
+    });
+    for (const it of order.items) {
+        INSERT_ITEM.run(order.id, it.id, it.quantity, it.price);
+    }
+});
 
 function insert(order) {
-    const orders = loadAll();
-    orders.push(order);
-    saveAll(orders);
+    insertTx(order);
     return order;
 }
 
 function findById(orderId) {
-    return loadAll().find((o) => o.id === orderId) || null;
+    return hydrate(FIND_ORDER.get(orderId));
 }
 
 function findByCustomerId(customerId) {
-    return loadAll().filter((o) => o.customerId === customerId);
+    return FIND_ORDERS_BY_USER.all(customerId).map(hydrate);
 }
 
 module.exports = { insert, findById, findByCustomerId };


### PR DESCRIPTION
## Resumo

Migra a persistência de **cupons** (US-22) e **pedidos** (US-24) de JSON para SQLite, seguindo a infra introduzida no PR #43 (`connection.js` + migration runner).

Closes #38
Closes #40

## US-22 — Cupons
- Migration `003_create_coupons.sql`: tabela `coupons` (`code` PK, `discount`, `type` ENUM via CHECK, `validade`, `max_uses`, `used_count`, timestamps)
- Seed dos 10 cupons de `coupons.json` (`INSERT OR IGNORE`, idempotente)
- `coupon.repository.js` refatorado para SQL; validação de expiração feita por query (`validade IS NULL OR validade >= date('now')`)
- `POST /api/v1/coupons/validate` sem mudança contratual

## US-24 — Pedidos
- Migration `005_create_orders.sql`: `orders` (`id` TEXT PK preservando `ord-<hex>`, `status` ENUM via CHECK, `total`, FK→users) + `order_items` (FK→orders/products, `unit_price_snapshot`)
- Índice `idx_orders_user_created` em `(user_id, created_at DESC)` para histórico
- `order.repository.js` refatorado: `insert` grava order+items em transação com snapshot de preço; `findById`/`findByCustomerId` reconstroem o objeto completo
- Campos não-normalizáveis (customer, endereços) guardados em colunas JSON para preservar o contrato
- `POST /orders`, `GET /orders/:orderId`, `GET /customers/:customerId/orders` sem mudança contratual

## Notas
- As FKs `users`/`products` são declaradas mas as tabelas pai dependem das US-20/US-21 (mesmo padrão já adotado em `004_create_carts.sql`)
- Migrations aplicam limpas via `npm run db:migrate`