### PR TITLE
[US-20] Tabela users + refatorar user.repository.js

### DIFF
--- a/backend/src/db/migrations/001_create_users.sql
+++ b/backend/src/db/migrations/001_create_users.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS users (
-    id TEXT PRIMARY KEY,
+    id TEXT NOT NULL PRIMARY KEY,
     email TEXT UNIQUE,
     nome TEXT,
     senha_hash TEXT,
@@ -7,4 +7,3 @@ CREATE TABLE IF NOT EXISTS users (
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
-CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email ON users (email) WHERE email IS NOT NULL;

--- a/backend/src/db/migrations/001_create_users.sql
+++ b/backend/src/db/migrations/001_create_users.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    email TEXT UNIQUE,
+    nome TEXT,
+    senha_hash TEXT,
+    role TEXT NOT NULL DEFAULT 'guest',
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email ON users (email) WHERE email IS NOT NULL;

--- a/backend/src/repositories/user.repository.js
+++ b/backend/src/repositories/user.repository.js
@@ -1,22 +1,12 @@
-const fs = require('fs');
-const path = require('path');
+const db = require('../db/connection');
 
-const USERS_FILE = path.join(__dirname, '..', 'data', 'users.json');
-
-function loadAll() {
-    if (!fs.existsSync(USERS_FILE)) return [];
-    const raw = fs.readFileSync(USERS_FILE, 'utf8');
-    return raw.trim() ? JSON.parse(raw) : [];
-}
-
-function saveAll(users) {
-    fs.writeFileSync(USERS_FILE, JSON.stringify(users, null, 2));
-}
+const INSERT_USER = db.prepare(`
+    INSERT OR IGNORE INTO users (id, email, nome, senha_hash, role, created_at)
+    VALUES (@id, null, null, null, 'guest', @created_at)
+`);
 
 function insert(user) {
-    const users = loadAll();
-    users.push(user);
-    saveAll(users);
+    INSERT_USER.run({ id: user.userId, created_at: user.createdAt });
     return user;
 }
 


### PR DESCRIPTION
## Summary

- Cria migration `001_create_users.sql` com tabela `users` (id, email, nome, senha_hash, role, created_at, updated_at) e índice parcial único em email
- Refatora `user.repository.js` para usar SQLite via better-sqlite3, mantendo a mesma interface pública (`insert`)

## Test plan

- [ ] `npm run db:migrate` roda sem erro
- [ ] `POST /api/v1/users` continua respondendo igual (sem regressão na US-17)
- [ ] Smoke test: criar sessão guest via cURL e verificar que o userId aparece na tabela `users`

Closes #36