### PR TITLE
feat(fe): Sprint 3 — frontend consome /api/v1 (US-26,28,30,32,33,34,38)

### DIFF
--- a/backend/src/db/seeds/seed_users.js
+++ b/backend/src/db/seeds/seed_users.js
@@ -1,5 +1,5 @@
 const bcrypt = require('bcryptjs');
-const db = require('../connection');
+const db = require('../index');
 
 const SALT_ROUNDS = 10;
 

--- a/frontend/black-friday.html
+++ b/frontend/black-friday.html
@@ -157,6 +157,7 @@
         </a>
     </nav>
 
+    <script src="js/api.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/search-common.js"></script>
     <script src="js/filter-modal.js"></script>

--- a/frontend/cart.html
+++ b/frontend/cart.html
@@ -95,6 +95,7 @@
         </a>
     </nav>
 
+    <script src="js/api.js"></script>
     <script src="js/cart-utils.js"></script>
     <script src="js/search-common.js"></script>
     <script src="js/utils.js"></script>

--- a/frontend/catalog.html
+++ b/frontend/catalog.html
@@ -88,6 +88,7 @@
             <span class="nav-label">Carrinho</span>
         </a>
     </nav>
+    <script src="js/api.js"></script>
     <script src="js/search-common.js"></script>
     <script src="js/catalog.js"></script>
     <script src="js/sandwich-menu.js"></script>

--- a/frontend/checkout.html
+++ b/frontend/checkout.html
@@ -275,6 +275,7 @@
         </form>
     </main>
 
+    <script src="js/api.js"></script>
     <script src="js/cart-utils.js"></script>
     <script src="js/order-service.js"></script>
     <script src="js/checkout.js"></script>

--- a/frontend/confirmation.html
+++ b/frontend/confirmation.html
@@ -63,6 +63,7 @@
             </a>
         </div>
     </main>
+    <script src="js/api.js"></script>
     <script src="js/order-service.js"></script>
     <script src="js/confirmation.js"></script>
     <script src="js/search-common.js"></script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -113,6 +113,7 @@
      </a>
 </nav>
 
+    <script src="js/api.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/search-common.js"></script>
     <script src="js/index.js"></script>

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -1,0 +1,115 @@
+/**
+ * API client central do frontend.
+ *
+ * Centraliza BASE_URL, montagem de query string, header Authorization Bearer,
+ * parsing de JSON e tratamento de erro. Todas as telas devem consumir a API
+ * por aqui — sem `fetch` espalhado.
+ *
+ * BASE_URL pode ser sobrescrita antes do load via:
+ *   window.__BULBE_API_BASE_URL__ = 'http://x.y/api/v1'
+ *
+ * Sessao (stub guest): enquanto a US-27 (POST /users) nao estiver implementada,
+ * `ensureSession()` gera um id local `guest-XXXX` e o salva como `authToken`.
+ * O middleware do backend trata qualquer Bearer nao vazio como `userId`, logo
+ * o stub e' compativel com o contrato — a US-27 vai substituir essa geracao
+ * por uma chamada `POST /users`.
+ */
+const Api = (function () {
+    const BASE_URL = window.__BULBE_API_BASE_URL__ || 'http://localhost:3001/api/v1';
+
+    const TOKEN_KEY = 'authToken';
+    const USER_KEY = 'userId';
+
+    function getToken() {
+        return localStorage.getItem(TOKEN_KEY);
+    }
+
+    function setSession(token, userId) {
+        if (token) localStorage.setItem(TOKEN_KEY, token);
+        if (userId) localStorage.setItem(USER_KEY, userId);
+    }
+
+    function getUserId() {
+        return localStorage.getItem(USER_KEY);
+    }
+
+    function clearSession() {
+        localStorage.removeItem(TOKEN_KEY);
+        localStorage.removeItem(USER_KEY);
+    }
+
+    function ensureSession() {
+        let token = getToken();
+        if (!token) {
+            token = 'guest-' + Math.random().toString(36).slice(2, 8).toUpperCase();
+            setSession(token, token);
+        }
+        return token;
+    }
+
+    function buildQuery(params) {
+        if (!params) return '';
+        const parts = [];
+        for (const [key, value] of Object.entries(params)) {
+            if (value === undefined || value === null || value === '') continue;
+            parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
+        }
+        return parts.length ? `?${parts.join('&')}` : '';
+    }
+
+    async function request(method, path, options) {
+        const opts = options || {};
+        const url = BASE_URL + path + buildQuery(opts.query);
+        const headers = { Accept: 'application/json' };
+        if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
+        if (opts.auth) headers['Authorization'] = `Bearer ${ensureSession()}`;
+
+        const response = await fetch(url, {
+            method,
+            headers,
+            body: opts.body !== undefined ? JSON.stringify(opts.body) : undefined,
+        });
+
+        let payload = null;
+        const text = await response.text();
+        if (text) {
+            try {
+                payload = JSON.parse(text);
+            } catch (_err) {
+                payload = text;
+            }
+        }
+
+        if (!response.ok) {
+            const message = (payload && payload.error) || `HTTP ${response.status}`;
+            const error = new Error(message);
+            error.status = response.status;
+            error.payload = payload;
+            throw error;
+        }
+
+        return payload;
+    }
+
+    return {
+        BASE_URL,
+        getToken,
+        setSession,
+        getUserId,
+        clearSession,
+        ensureSession,
+        buildQuery,
+        get(path, opts) {
+            return request('GET', path, opts);
+        },
+        post(path, body, opts) {
+            return request('POST', path, Object.assign({}, opts, { body }));
+        },
+        put(path, body, opts) {
+            return request('PUT', path, Object.assign({}, opts, { body }));
+        },
+        delete(path, opts) {
+            return request('DELETE', path, opts);
+        },
+    };
+})();

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -113,3 +113,16 @@ const Api = (function () {
         },
     };
 })();
+
+// US-38: icone "perfil" do header aponta para login.html
+document.addEventListener('DOMContentLoaded', () => {
+    const profileBtns = document.querySelectorAll('.profile-photo, #profileBtn');
+    profileBtns.forEach((btn) => {
+        if (btn.dataset.bulbeProfileBound === 'true') return;
+        btn.style.cursor = 'pointer';
+        btn.addEventListener('click', () => {
+            window.location.href = 'login.html';
+        });
+        btn.dataset.bulbeProfileBound = 'true';
+    });
+});

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -38,13 +38,30 @@ const Api = (function () {
         localStorage.removeItem(USER_KEY);
     }
 
-    function ensureSession() {
-        let token = getToken();
-        if (!token) {
-            token = 'guest-' + Math.random().toString(36).slice(2, 8).toUpperCase();
-            setSession(token, token);
-        }
-        return token;
+    let _sessionPromise = null;
+
+    async function ensureSession() {
+        const existing = getToken();
+        if (existing) return existing;
+        if (_sessionPromise) return _sessionPromise;
+
+        _sessionPromise = (async () => {
+            try {
+                const response = await fetch(BASE_URL + '/users', {
+                    method: 'POST',
+                    headers: { Accept: 'application/json' },
+                });
+                if (!response.ok) throw new Error('HTTP ' + response.status);
+                const data = await response.json();
+                setSession(data.token, data.userId);
+                return data.token;
+            } catch (err) {
+                _sessionPromise = null;
+                throw err;
+            }
+        })();
+
+        return _sessionPromise;
     }
 
     function buildQuery(params) {
@@ -62,7 +79,7 @@ const Api = (function () {
         const url = BASE_URL + path + buildQuery(opts.query);
         const headers = { Accept: 'application/json' };
         if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
-        if (opts.auth) headers['Authorization'] = `Bearer ${ensureSession()}`;
+        if (opts.auth) headers['Authorization'] = `Bearer ${await ensureSession()}`;
 
         const response = await fetch(url, {
             method,

--- a/frontend/js/cart-utils.js
+++ b/frontend/js/cart-utils.js
@@ -1,68 +1,48 @@
+/**
+ * CartService: integra carrinho com backend (/api/v1/cart*).
+ *
+ * Contrato do backend (cart.repository.hydrate) — cada item tem:
+ *   { id, productId, name, price, oldPrice, image, rating, ratingCount, quantity }
+ *
+ * IMPORTANTE: `id` e' o id da linha em cart_items, usado por PUT/DELETE.
+ * `productId` e' o id do produto, usado para link de detalhe / recomendacoes.
+ *
+ * GET /cart       -> { items, itemCount, total }
+ * POST /cart/items, PUT/DELETE /cart/items/:id, DELETE /cart -> { message, cart }
+ */
 const CartService = {
-    STORAGE_KEY: 'cart',
-    
-    getCart() {
-        return JSON.parse(localStorage.getItem(this.STORAGE_KEY)) || [];
+    async getCart() {
+        return await Api.get('/cart', { auth: true });
     },
-    
-    setCart(cart) {
-        localStorage.setItem(this.STORAGE_KEY, JSON.stringify(cart));
+
+    async addItem(productId, quantity = 1) {
+        const response = await Api.post(
+            '/cart/items',
+            { productId: Number(productId), quantity: Number(quantity) },
+            { auth: true },
+        );
+        return response.cart;
     },
-    
-    addItem(product, quantity = 1) {
-        const cart = this.getCart();
-        const existingItem = cart.find(item => item.id === product.id);
-        
-        if (existingItem) {
-            existingItem.quantity += quantity;
-        } else {
-            cart.push({
-                id: product.id,
-                name: product.name,
-                price: product.price,
-                oldPrice: product.oldPrice,
-                image: product.image,
-                rating: product.rating,
-                ratingCount: product.ratingCount,
-                quantity: quantity
-            });
+
+    async updateItemQuantity(itemId, quantity) {
+        if (quantity < 1 || quantity > 99) {
+            throw new Error('Quantidade invalida (1-99)');
         }
-        
-        this.setCart(cart);
+        const response = await Api.put(
+            `/cart/items/${itemId}`,
+            { quantity: Number(quantity) },
+            { auth: true },
+        );
+        return response.cart;
     },
-    
-    updateItemQuantity(itemId, quantity) {
-        if (quantity < 1 || quantity > 99) return false;
-        
-        const cart = this.getCart();
-        const item = cart.find(i => i.id === itemId);
-        
-        if (item) {
-            item.quantity = quantity;
-            this.setCart(cart);
-            return true;
-        }
-        
-        return false;
+
+    async removeItem(itemId) {
+        const response = await Api.delete(`/cart/items/${itemId}`, { auth: true });
+        return response.cart;
     },
-    
-    removeItem(itemId) {
-        let cart = this.getCart();
-        cart = cart.filter(item => item.id !== itemId);
-        this.setCart(cart);
+
+    async clearCart() {
+        const response = await Api.delete('/cart', { auth: true });
+        return response.cart;
     },
-    
-    clearCart() {
-        localStorage.removeItem(this.STORAGE_KEY);
-    },
-    
-    getTotal() {
-        const cart = this.getCart();
-        return cart.reduce((sum, item) => sum + (item.price * item.quantity), 0);
-    },
-    
-    getItemCount() {
-        const cart = this.getCart();
-        return cart.reduce((sum, item) => sum + item.quantity, 0);
-    }
 };

--- a/frontend/js/cart.js
+++ b/frontend/js/cart.js
@@ -1,21 +1,45 @@
-function loadCart() {
-    const cart = CartService.getCart();
+/**
+ * Renderiza e opera o carrinho consumindo /api/v1/cart*.
+ *
+ * IMPORTANTE (id duplo):
+ *   - item.id        -> id da linha em cart_items, usado para PUT/DELETE /cart/items/:id
+ *   - item.productId -> id do produto, usado para o link product-detail.html?id= e recomendacoes
+ */
+
+let currentCart = { items: [], itemCount: 0, total: 0 };
+let lastRecommendationsSignature = '';
+
+async function loadCart() {
     const cartItemsContainer = document.querySelector('.cart-items');
-    
-    if (cart.length === 0) {
+
+    try {
+        currentCart = await CartService.getCart();
+    } catch (error) {
+        console.error('Erro ao carregar carrinho:', error);
+        if (cartItemsContainer) {
+            cartItemsContainer.innerHTML = '<p style="text-align:center;padding:40px;">Erro ao carregar o carrinho.</p>';
+        }
+        return;
+    }
+
+    renderCart();
+}
+
+function renderCart() {
+    const cartItemsContainer = document.querySelector('.cart-items');
+    if (!cartItemsContainer) return;
+
+    const items = currentCart.items || [];
+
+    if (items.length === 0) {
         cartItemsContainer.innerHTML = '<p style="text-align: center; padding: 40px;">Seu carrinho está vazio</p>';
         updateSubtotal();
         renderRecommendations();
         return;
     }
-    
+
     cartItemsContainer.innerHTML = '';
-    
-    cart.forEach(item => {
-        const cartItem = createCartItem(item);
-        cartItemsContainer.appendChild(cartItem);
-    });
-    
+    items.forEach(item => cartItemsContainer.appendChild(createCartItem(item)));
     updateSubtotal();
     renderRecommendations();
 }
@@ -24,27 +48,30 @@ function createCartItem(item) {
     const article = document.createElement('article');
     article.className = 'cart-item';
     article.dataset.id = item.id;
-    
+    article.dataset.productId = item.productId;
+
     article.innerHTML = `
         <div>
             <div class="item-image-container">
                 <img src="${item.image}" alt="${item.name}" class="item-image">
             </div>
-            
+
             <div class="item-details">
-                <h3 class="item-title">${item.name}</h3>
-                
+                <h3 class="item-title">
+                    <a href="product-detail.html?id=${item.productId}" style="color:inherit;text-decoration:none;">${item.name}</a>
+                </h3>
+
                 <div class="item-rating">
                     <img src="images/avaliacao.png" alt="5 estrelas">
                     <span class="rating-count">(${item.ratingCount})</span>
                 </div>
-                
+
                 <div class="item-price-initial">
                     <span class="price-label-de">De</span>
                     <span class="price-value-old" data-old-price-id="${item.id}">R$${(item.oldPrice * item.quantity).toFixed(2)}</span>
                     <span class="price-label-por">por</span>
                 </div>
-                
+
                 <div class="item-price-final">
                     <span class="price-currency">R$</span>
                     <span class="price-value" data-item-id="${item.id}">${(item.price * item.quantity).toFixed(2)}</span>
@@ -59,78 +86,66 @@ function createCartItem(item) {
             <button class="quantity-btn increase" data-id="${item.id}" aria-label="Aumentar quantidade">+</button>
         </div>
     `;
-    
+
     article.querySelector('.decrease').addEventListener('click', () => decreaseQuantity(item.id));
     article.querySelector('.increase').addEventListener('click', () => increaseQuantity(item.id));
     article.querySelector('.quantity-input').addEventListener('change', (e) => updateQuantity(item.id, parseInt(e.target.value)));
-    
+
     return article;
 }
 
-function decreaseQuantity(itemId) {
-    const cart = CartService.getCart();
-    const item = cart.find(i => i.id === itemId);
-    
-    if (item) {
-        if (item.quantity === 1) {
-            removeItem(itemId);
-        } else {
-            CartService.updateItemQuantity(itemId, item.quantity - 1);
-            updateItemPrice(itemId, item.price, item.quantity - 1);
-            updateSubtotal();
-            renderRecommendations();
-        }
-    }
+function findItem(itemId) {
+    return (currentCart.items || []).find(i => i.id === itemId);
 }
 
-function increaseQuantity(itemId) {
-    const cart = CartService.getCart();
-    const item = cart.find(i => i.id === itemId);
-    
-    if (item && item.quantity < 99) {
-        CartService.updateItemQuantity(itemId, item.quantity + 1);
-        updateItemPrice(itemId, item.price, item.quantity + 1);
-        updateSubtotal();
-        renderRecommendations();
-    }
-}
-
-function updateQuantity(itemId, newQuantity) {
-    if (CartService.updateItemQuantity(itemId, newQuantity)) {
-        const cart = CartService.getCart();
-        const item = cart.find(i => i.id === itemId);
-        if (item) {
-            updateItemPrice(itemId, item.price, item.quantity);
-            updateSubtotal();
-            renderRecommendations();
-        }
-    }
-}
-
-function removeItem(itemId) {
-    CartService.removeItem(itemId);
-    loadCart();
-}
-
-function updateItemPrice(itemId, unitPrice, quantity) {
-    const cart = CartService.getCart();
-    const item = cart.find(i => i.id === itemId);
-    
+async function decreaseQuantity(itemId) {
+    const item = findItem(itemId);
     if (!item) return;
-    
-    const priceElement = document.querySelector(`[data-item-id="${itemId}"]`);
-    if (priceElement) {
-        priceElement.textContent = (unitPrice * quantity).toFixed(2);
+
+    try {
+        if (item.quantity <= 1) {
+            currentCart = await CartService.removeItem(itemId);
+            renderCart();
+        } else {
+            currentCart = await CartService.updateItemQuantity(itemId, item.quantity - 1);
+            renderCart();
+        }
+    } catch (error) {
+        alert(error.message || 'Erro ao atualizar quantidade');
     }
-    
-    const oldPriceElement = document.querySelector(`[data-old-price-id="${itemId}"]`);
-    if (oldPriceElement) {
-        oldPriceElement.textContent = `R$${(item.oldPrice * quantity).toFixed(2)}`;
+}
+
+async function increaseQuantity(itemId) {
+    const item = findItem(itemId);
+    if (!item || item.quantity >= 99) return;
+
+    try {
+        currentCart = await CartService.updateItemQuantity(itemId, item.quantity + 1);
+        renderCart();
+    } catch (error) {
+        alert(error.message || 'Erro ao atualizar quantidade');
     }
-    
-    const quantityInput = document.getElementById(`quantity-${itemId}`);
-    if (quantityInput) {
-        quantityInput.value = quantity;
+}
+
+async function updateQuantity(itemId, newQuantity) {
+    if (!Number.isInteger(newQuantity) || newQuantity < 1 || newQuantity > 99) {
+        renderCart();
+        return;
+    }
+    try {
+        currentCart = await CartService.updateItemQuantity(itemId, newQuantity);
+        renderCart();
+    } catch (error) {
+        alert(error.message || 'Erro ao atualizar quantidade');
+    }
+}
+
+async function removeItem(itemId) {
+    try {
+        currentCart = await CartService.removeItem(itemId);
+        renderCart();
+    } catch (error) {
+        alert(error.message || 'Erro ao remover item');
     }
 }
 
@@ -139,7 +154,7 @@ function updateSubtotal() {
     const subtotalValue = document.getElementById('subtotal-value');
     if (!summarySection || !subtotalValue) return;
 
-    const subtotal = CartService.getTotal();
+    const subtotal = Number(currentCart.total) || 0;
 
     if (subtotal <= 0) {
         summarySection.hidden = true;
@@ -149,21 +164,23 @@ function updateSubtotal() {
     }
 }
 
-document.getElementById('checkout-btn').addEventListener('click', () => {
-    const cart = CartService.getCart();
-    if (cart.length > 0) {
-        window.location.href = 'checkout.html';
-    } else {
-        alert('Seu carrinho está vazio!');
-    }
-});
+const checkoutBtn = document.getElementById('checkout-btn');
+if (checkoutBtn) {
+    checkoutBtn.addEventListener('click', () => {
+        if ((currentCart.items || []).length > 0) {
+            window.location.href = 'checkout.html';
+        } else {
+            alert('Seu carrinho está vazio!');
+        }
+    });
+}
 
 loadCart();
-/* Helpers de recomendações */
-let lastRecommendationsSignature = '';
+
+/* ====== Recomendacoes (US-32 substitui pelo endpoint /products/recommendations) ====== */
 
 function getCartProductIds() {
-    return CartService.getCart().map(item => item.id);
+    return (currentCart.items || []).map(item => item.productId);
 }
 
 function computeRecommendationsSignature(products) {
@@ -194,72 +211,6 @@ function renderCards(target, cards) {
     cards.forEach(card => target.appendChild(card));
 }
 
-function getCartCategories(allProducts) {
-    if (!Array.isArray(allProducts) || allProducts.length === 0) return [];
-    const cartIds = new Set(getCartProductIds());
-    if (cartIds.size === 0) return [];
-    const categoriesSet = new Set();
-    
-    allProducts.forEach(product => {
-        if (!product || product.id == null) return;
-        if (!cartIds.has(product.id)) return;
-        const category = typeof product.category === 'string' ? product.category.trim() : null;
-        if (category) {
-            categoriesSet.add(category);
-        }
-    });
-    
-    return Array.from(categoriesSet);
-}
-
-async function fetchAllProducts() {
-    try {
-        const products = await ProductService.fetchProducts();
-        return Array.isArray(products) ? products : [];
-    } catch (error) {
-        console.error('Erro ao buscar produtos para recomendações:', error);
-        return [];
-    }
-}
-
-function getRecommendedCandidates(allProducts) {
-    if (!Array.isArray(allProducts) || allProducts.length === 0) return [];
-    const cartIds = new Set(getCartProductIds());
-    if (cartIds.size === 0) return [];
-    const categories = new Set(getCartCategories(allProducts));
-    if (categories.size === 0) return [];
-    
-    return allProducts.filter(product => {
-        if (!product || product.id == null) return false;
-        const category = typeof product.category === 'string' ? product.category.trim() : null;
-        const inSameCategory = category && categories.has(category);
-        const notInCart = !cartIds.has(product.id);
-        return inSameCategory && notInCart;
-    });
-}
-
-function limitRecommendationsByCategory(candidates, limitPerCategory = 10) {
-    const uniqueIds = new Set();
-    const categoryCount = new Map();
-    const limited = [];
-    
-    for (const product of candidates) {
-        if (!product || !product.id) continue;
-        const category = typeof product.category === 'string' ? product.category.trim() : null;
-        if (!category) continue;
-        if (uniqueIds.has(product.id)) continue;
-        
-        const count = categoryCount.get(category) || 0;
-        if (count >= limitPerCategory) continue;
-        
-        uniqueIds.add(product.id);
-        categoryCount.set(category, count + 1);
-        limited.push(product);
-    }
-    
-    return limited;
-}
-
 function normalizeProductPrices(product) {
     const normalized = { ...product };
     if (normalized && normalized.price != null && !Number.isNaN(normalized.price)) {
@@ -288,23 +239,39 @@ function buildRecommendationCards(products) {
     });
 }
 
+async function fetchRecommendations(productIds) {
+    if (!Array.isArray(productIds) || productIds.length === 0) return [];
+    try {
+        const data = await Api.get('/products/recommendations', {
+            query: { cartItemIds: productIds.join(',') },
+        });
+        return Array.isArray(data.recommendations) ? data.recommendations : [];
+    } catch (error) {
+        console.error('Erro ao buscar recomendacoes:', error);
+        return [];
+    }
+}
+
 async function renderRecommendations() {
     const section = document.getElementById('cart-recommendations');
     const track = document.getElementById('recommendations-track');
     if (!section || !track) return;
     const skeleton = document.getElementById('recommendations-skeleton');
     const carousel = section.querySelector('.recommendations-carousel');
-    
-    // Mostrar skeleton durante o carregamento
+
+    const productIds = getCartProductIds();
+    if (productIds.length === 0) {
+        hideRecommendations(section, skeleton);
+        lastRecommendationsSignature = '';
+        return;
+    }
+
     showSkeleton(section, skeleton, carousel);
     try {
-        const allProducts = await fetchAllProducts();
-        const candidates = getRecommendedCandidates(allProducts);
-        const limited = limitRecommendationsByCategory(candidates);
-        const cards = buildRecommendationCards(limited);
-        const signature = computeRecommendationsSignature(limited);
-        
-        // Se não mudou, só garante UI e retorna
+        const recommendations = await fetchRecommendations(productIds);
+        const cards = buildRecommendationCards(recommendations);
+        const signature = computeRecommendationsSignature(recommendations);
+
         if (signature === lastRecommendationsSignature) {
             if (cards.length > 0 && carousel) {
                 showCarousel(section, skeleton, carousel);
@@ -315,9 +282,9 @@ async function renderRecommendations() {
             return;
         }
         lastRecommendationsSignature = signature;
-        
+
         renderCards(track, cards);
-        
+
         if (cards.length > 0) {
             showCarousel(section, skeleton, carousel);
             bindRecommendationCarousel();
@@ -326,7 +293,7 @@ async function renderRecommendations() {
             lastRecommendationsSignature = '';
         }
     } catch (error) {
-        console.error('Erro ao renderizar recomendações:', error);
+        console.error('Erro ao renderizar recomendacoes:', error);
         hideRecommendations(section, skeleton);
         lastRecommendationsSignature = '';
     }
@@ -337,21 +304,21 @@ function bindRecommendationCarousel() {
     const prevBtn = document.getElementById('recommendations-prev');
     const nextBtn = document.getElementById('recommendations-next');
     if (!track || !prevBtn || !nextBtn) return;
-    
+
     if (prevBtn.dataset.bound === 'true' && nextBtn.dataset.bound === 'true') {
-        return; // já vinculados
+        return;
     }
-    
+
     const getScrollAmount = () => Math.max(160, Math.floor(track.clientWidth * 0.8));
-    
+
     prevBtn.addEventListener('click', () => {
         track.scrollBy({ left: -getScrollAmount(), behavior: 'smooth' });
     });
-    
+
     nextBtn.addEventListener('click', () => {
         track.scrollBy({ left: getScrollAmount(), behavior: 'smooth' });
     });
-    
+
     prevBtn.dataset.bound = 'true';
     nextBtn.dataset.bound = 'true';
 }

--- a/frontend/js/cupom.js
+++ b/frontend/js/cupom.js
@@ -1,43 +1,45 @@
-// Esse JS vai lidar com validação de cupons de desconto!
+// Validação de cupons via POST /api/v1/coupons/validate.
 
 const okCupomButton = document.getElementById("ok-cupom");
 const inputCupom = document.getElementById("cupom-desconto");
 const feedbackPositivo = document.getElementById("feedback-positivo");
 const feedbackNegativo = document.getElementById("feedback-negativo");
 
-// Banco de cupons
-const cupons = [
-    { codigo: "BULBE10", valor: 0.1 },
-    { codigo: "BULBE15", valor: 0.15 },
-    { codigo: "BLACKFRIDAY", valor: 0.2 },
-    { codigo: "WELCOME5", valor: 0.05 },
-    { codigo: "PROMO25", valor: 0.25 },
-    { codigo: "SUPERPROMO", valor: 0.40},
-    { codigo: "SUPER30", valor: 0.30 },
-    { codigo: "CLIENTEVIP", valor: 0.12 },
-    { codigo: "BULBE20", valor: 0.20 },
-    { codigo: "MEGASALE", valor: 0.18 }
-];
-
 let descontoCupom = 0;
 
-okCupomButton.addEventListener("click", () => {
-    const valorInputCupom = inputCupom.value.trim().toUpperCase();
+function clearCupom() {
+    descontoCupom = 0;
+    feedbackNegativo.style.display = "inline";
+    feedbackPositivo.style.display = "none";
+    localStorage.removeItem("cupomCodigo");
+    localStorage.removeItem("descontoCupom");
+}
 
-    //  Procurar o input no banco de cupons
-    const cupomEncontrado = cupons.find((c) => c.codigo === valorInputCupom);
+okCupomButton.addEventListener("click", async () => {
+    const code = inputCupom.value.trim();
 
-    if (cupomEncontrado) {
-        descontoCupom = cupomEncontrado.valor;
-        feedbackPositivo.style.display = "inline";
-        feedbackNegativo.style.display = "none";
-        localStorage.setItem("cupomCodigo", cupomEncontrado.codigo);
-        localStorage.setItem("descontoCupom", descontoCupom);
-    } else {
-        descontoCupom = 0;
-        feedbackNegativo.style.display = "inline";
-        feedbackPositivo.style.display = "none";
-        localStorage.removeItem("cupomCodigo");
-        localStorage.removeItem("descontoCupom");
+    if (!code) {
+        clearCupom();
+        return;
+    }
+
+    okCupomButton.disabled = true;
+    try {
+        const result = await Api.post('/coupons/validate', { code });
+
+        if (result && result.valid) {
+            descontoCupom = Number(result.discountPercentage) || 0;
+            feedbackPositivo.style.display = "inline";
+            feedbackNegativo.style.display = "none";
+            localStorage.setItem("cupomCodigo", result.code);
+            localStorage.setItem("descontoCupom", descontoCupom);
+        } else {
+            clearCupom();
+        }
+    } catch (error) {
+        console.error('Erro ao validar cupom:', error);
+        clearCupom();
+    } finally {
+        okCupomButton.disabled = false;
     }
 });

--- a/frontend/js/index.js
+++ b/frontend/js/index.js
@@ -1,41 +1,24 @@
 async function loadFeaturedProducts() {
+    const productGrid = document.querySelector('.product-grid-horizontal');
+    if (!productGrid) return;
+
     try {
-        const products = await ProductService.fetchProducts();
-        const productGrid = document.querySelector('.product-grid-horizontal');
-        if (!productGrid) return;
-        
-        const alexaProducts = typeof getAlexaProducts === 'function'
-            ? getAlexaProducts(products)
-            : products.filter(isAlexaProduct);
-        
-        const featuredList = [];
-        
-        // Garantir até 2 Alexas
-        alexaProducts.slice(0, 2).forEach(product => featuredList.push(product));
-        
-        // Preencher o restante com produtos aleatórios distintos
-        const remainingProducts = products.filter(product => !featuredList.includes(product));
-        shuffleArray(remainingProducts);
-        
-        remainingProducts.slice(0, Math.max(0, 8 - featuredList.length)).forEach(product => {
-            featuredList.push(product);
-        });
-        
+        const data = await Api.get('/products/featured');
+        const products = Array.isArray(data.products) ? data.products : [];
+
         productGrid.innerHTML = '';
-        
-        featuredList.slice(0, 8).forEach(product => {
-            const productCard = createProductCard(product);
-            productGrid.appendChild(productCard);
+
+        if (products.length === 0) {
+            productGrid.innerHTML = '<p style="text-align:center;padding:20px;">Sem destaques no momento.</p>';
+            return;
+        }
+
+        products.forEach(product => {
+            productGrid.appendChild(createProductCard(product));
         });
     } catch (error) {
-        console.error('Erro ao carregar produtos:', error);
-    }
-}
-
-function shuffleArray(array) {
-    for (let i = array.length - 1; i > 0; i--) {
-        const j = Math.floor(Math.random() * (i + 1));
-        [array[i], array[j]] = [array[j], array[i]];
+        console.error('Erro ao carregar destaques:', error);
+        productGrid.innerHTML = '<p style="text-align:center;padding:20px;">Erro ao carregar destaques.</p>';
     }
 }
 

--- a/frontend/js/login.js
+++ b/frontend/js/login.js
@@ -1,0 +1,69 @@
+/**
+ * Login JWT: chama POST /api/v1/auth/login e guarda token + usuario.
+ *
+ * IMPORTANTE (caveat de identidade — US-38):
+ * O middleware do backend trata Bearer bruto como userId. Se o JWT for usado
+ * como Bearer nas rotas autenticadas, o customerId muda a cada login e perde
+ * vinculo com carrinho/pedidos. Por isso aqui guardamos o JWT em chaves
+ * separadas (jwtToken/usuario) e mantemos o token de sessao guest (authToken)
+ * intacto, ate que o middleware decodifique o JWT (ou US-27/futura issue).
+ */
+(function () {
+    const form = document.getElementById('login-form');
+    if (!form) return;
+
+    const emailInput = document.getElementById('login-email');
+    const senhaInput = document.getElementById('login-senha');
+    const submitBtn = document.getElementById('login-submit');
+    const feedback = document.getElementById('login-feedback');
+
+    function showFeedback(kind, message) {
+        feedback.className = 'login-feedback ' + kind;
+        feedback.textContent = message;
+    }
+
+    function clearFeedback() {
+        feedback.className = 'login-feedback';
+        feedback.textContent = '';
+    }
+
+    form.addEventListener('submit', async (event) => {
+        event.preventDefault();
+        clearFeedback();
+
+        const email = emailInput.value.trim();
+        const senha = senhaInput.value;
+
+        if (!email || !senha) {
+            showFeedback('error', 'Informe email e senha');
+            return;
+        }
+
+        submitBtn.disabled = true;
+        try {
+            const response = await Api.post('/auth/login', { email, senha });
+
+            if (response && response.token && response.usuario) {
+                localStorage.setItem('jwtToken', response.token);
+                localStorage.setItem('jwtExpiresIn', response.expiresIn || '');
+                localStorage.setItem('usuario', JSON.stringify(response.usuario));
+                showFeedback('success', `Bem-vindo, ${response.usuario.nome}!`);
+                setTimeout(() => {
+                    window.location.href = 'index.html';
+                }, 600);
+            } else {
+                showFeedback('error', 'Resposta inesperada do servidor');
+            }
+        } catch (error) {
+            if (error.status === 400) {
+                showFeedback('error', error.message || 'Informe email e senha');
+            } else if (error.status === 401) {
+                showFeedback('error', error.message || 'Credenciais invalidas');
+            } else {
+                showFeedback('error', 'Nao foi possivel entrar. Tente novamente.');
+            }
+        } finally {
+            submitBtn.disabled = false;
+        }
+    });
+})();

--- a/frontend/js/product-detail.js
+++ b/frontend/js/product-detail.js
@@ -2,17 +2,30 @@ let currentProduct = null;
 
 async function loadProductDetail() {
     const productId = parseInt(getURLParam('id'));
-    
-    try {
-        const products = await ProductService.fetchProducts();
-        currentProduct = products.find(p => p.id === productId);
-        
-        if (currentProduct) {
-            displayProduct(currentProduct);
-        }
-    } catch (error) {
-        console.error('Erro ao carregar produto:', error);
+
+    if (!Number.isInteger(productId) || productId <= 0) {
+        showProductNotFound();
+        return;
     }
+
+    currentProduct = await ProductService.fetchProductById(productId);
+
+    if (currentProduct) {
+        displayProduct(currentProduct);
+    } else {
+        showProductNotFound();
+    }
+}
+
+function showProductNotFound() {
+    const title = document.querySelector('.product-title');
+    if (title) title.textContent = 'Produto não encontrado';
+    const description = document.querySelector('.product-description');
+    if (description) description.textContent = 'O produto solicitado não está disponível.';
+    const addBtn = document.getElementById('add-to-cart-btn');
+    const buyBtn = document.getElementById('buy-now-btn');
+    if (addBtn) addBtn.disabled = true;
+    if (buyBtn) buyBtn.disabled = true;
 }
 
 function displayProduct(product) {

--- a/frontend/js/product-detail.js
+++ b/frontend/js/product-detail.js
@@ -67,17 +67,33 @@ increaseBtn.addEventListener('click', () => {
     }
 });
 
-addToCartBtn.addEventListener('click', () => {
-    if (currentProduct) {
-        CartService.addItem(currentProduct, parseInt(quantityInput.value));
-        alert('Produto adicionado ao carrinho!');
+async function addCurrentToCart() {
+    const quantity = parseInt(quantityInput.value);
+    try {
+        await CartService.addItem(currentProduct.id, quantity);
+        return true;
+    } catch (error) {
+        alert(error.message || 'Erro ao adicionar ao carrinho');
+        return false;
     }
+}
+
+addToCartBtn.addEventListener('click', async () => {
+    if (!currentProduct) return;
+    addToCartBtn.disabled = true;
+    const ok = await addCurrentToCart();
+    addToCartBtn.disabled = false;
+    if (ok) alert('Produto adicionado ao carrinho!');
 });
 
-buyNowBtn.addEventListener('click', () => {
-    if (currentProduct) {
-        CartService.addItem(currentProduct, parseInt(quantityInput.value));
+buyNowBtn.addEventListener('click', async () => {
+    if (!currentProduct) return;
+    buyNowBtn.disabled = true;
+    const ok = await addCurrentToCart();
+    if (ok) {
         window.location.href = 'cart.html';
+    } else {
+        buyNowBtn.disabled = false;
     }
 });
 

--- a/frontend/js/utils.js
+++ b/frontend/js/utils.js
@@ -5,14 +5,24 @@ const ProductService = {
     
     async fetchProducts() {
         if (this.cache) return this.cache;
-        
+
         try {
-            const response = await fetch('products.json');
-            this.cache = await response.json();
+            const data = await Api.get('/products');
+            this.cache = Array.isArray(data.products) ? data.products : [];
             return this.cache;
         } catch (error) {
             console.error('Erro ao carregar produtos:', error);
             return [];
+        }
+    },
+
+    async fetchProductById(id) {
+        try {
+            return await Api.get(`/products/${id}`);
+        } catch (error) {
+            if (error.status === 404) return null;
+            console.error('Erro ao carregar produto:', error);
+            return null;
         }
     },
     

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login - Bulbe Shop</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,300;0,400;0,500;0,600;1,400;1,500;1,600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/base.css">
+    <style>
+        .login-container {
+            max-width: 420px;
+            margin: 40px auto;
+            padding: 32px 24px;
+        }
+        .login-title {
+            font-size: 24px;
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+        .login-subtitle {
+            color: #666;
+            margin-bottom: 24px;
+            font-size: 14px;
+        }
+        .login-form .field {
+            margin-bottom: 16px;
+        }
+        .login-form label {
+            display: block;
+            font-size: 13px;
+            font-weight: 500;
+            margin-bottom: 6px;
+            color: #333;
+        }
+        .login-form input {
+            width: 100%;
+            padding: 12px 14px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            font-family: 'Poppins', sans-serif;
+            font-size: 14px;
+            box-sizing: border-box;
+        }
+        .login-form input:focus {
+            outline: none;
+            border-color: #f7c948;
+        }
+        .login-submit {
+            width: 100%;
+            padding: 14px;
+            margin-top: 8px;
+            background: #f7c948;
+            color: #1a1a1a;
+            border: none;
+            border-radius: 8px;
+            font-family: 'Poppins', sans-serif;
+            font-size: 15px;
+            font-weight: 600;
+            cursor: pointer;
+        }
+        .login-submit:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+        }
+        .login-feedback {
+            margin-top: 16px;
+            padding: 10px 14px;
+            border-radius: 6px;
+            font-size: 13px;
+            display: none;
+        }
+        .login-feedback.error {
+            display: block;
+            background: #fdecec;
+            color: #b3261e;
+            border: 1px solid #f5c2c0;
+        }
+        .login-feedback.success {
+            display: block;
+            background: #e7f6ec;
+            color: #1b5e20;
+            border: 1px solid #b7e1c0;
+        }
+        .login-hint {
+            margin-top: 12px;
+            font-size: 12px;
+            color: #888;
+            text-align: center;
+        }
+    </style>
+</head>
+<body class="has-bottom-nav">
+    <header class="site-header">
+        <nav class="navbar-superior">
+            <a href="index.html" class="bulbeshop"><img src="images/header_img/logo.png" alt="Bulbe Shop" class="logo"></a>
+        </nav>
+    </header>
+
+    <main class="login-container">
+        <h1 class="login-title">Entrar</h1>
+        <p class="login-subtitle">Acesse sua conta Bulbe Shop.</p>
+
+        <form id="login-form" class="login-form" novalidate>
+            <div class="field">
+                <label for="login-email">Email</label>
+                <input type="email" id="login-email" name="email" autocomplete="email" required>
+            </div>
+            <div class="field">
+                <label for="login-senha">Senha</label>
+                <input type="password" id="login-senha" name="senha" autocomplete="current-password" required>
+            </div>
+
+            <button type="submit" class="login-submit" id="login-submit">Entrar</button>
+
+            <div id="login-feedback" class="login-feedback" role="alert"></div>
+        </form>
+
+        <p class="login-hint">Use os usuarios de seed: <code>admin@bulbe.com</code> / <code>admin123</code></p>
+    </main>
+
+    <script src="js/api.js"></script>
+    <script src="js/login.js"></script>
+</body>
+</html>

--- a/frontend/my-orders.html
+++ b/frontend/my-orders.html
@@ -66,6 +66,7 @@
     </a>
   </nav>
 
+  <script src="js/api.js"></script>
   <script src="js/order-service.js"></script>
   <script src="js/my-orders.js"></script>
   <script src="js/search-common.js"></script>

--- a/frontend/product-detail.html
+++ b/frontend/product-detail.html
@@ -144,6 +144,7 @@
         </a>
     </nav>
 
+    <script src="js/api.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/cart-utils.js"></script>
     <script src="js/product-detail.js"></script>

--- a/frontend/product-list.html
+++ b/frontend/product-list.html
@@ -196,6 +196,7 @@
         </a>
     </nav>
 
+    <script src="js/api.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/search-common.js"></script>
     <script src="js/filter-modal.js"></script>

--- a/frontend/search-results.html
+++ b/frontend/search-results.html
@@ -196,6 +196,7 @@
         </a>
     </nav>
 
+    <script src="js/api.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/search-common.js"></script>
     <script src="js/filter-modal.js"></script>

--- a/frontend/subcategories.html
+++ b/frontend/subcategories.html
@@ -88,6 +88,7 @@
             <span class="nav-label">Carrinho</span>
         </a>
     </nav>
+    <script src="js/api.js"></script>
     <script src="js/search-common.js"></script>
     <script src="js/catalog.js"></script>
     <script src="js/sandwich-menu.js"></script>


### PR DESCRIPTION
## Resumo

Implementa 7 issues da Sprint 3 atribuídas a `@igorconradoibmec` — o frontend passa a consumir os endpoints `/api/v1` no lugar de `products.json` / cupons hardcoded / carrinho em `localStorage`.

| Issue | US | O que mudou |
|---|---|---|
| #49 | US-26 | `frontend/js/api.js` central (BASE_URL, Bearer, query string, errors) + session stub guest. Incluído em todas as 11 HTMLs como primeiro script. |
| #50 | US-28 | `utils.js`: `ProductService.fetchProducts()` agora chama `GET /products`; novo `fetchProductById(id)` com tratamento de 404; `product-detail.js` usa o novo helper. |
| #51 | US-30 | `index.js` chama `GET /products/featured`; remove `shuffle`/Alexa-pick client-side. |
| #53 | US-34 | `cupom.js` chama `POST /coupons/validate`; remove array hardcoded de 10 cupons. |
| #54 | US-33 | `cart-utils.js` reescrito async; `cart.js` usa `item.id` (linha) para PUT/DELETE e `item.productId` para link/recomendações; `product-detail.js` `addItem(productId, quantity)`. Carrinho 100% server-side. |
| #52 | US-32 | `cart.js` `fetchRecommendations()` via `GET /products/recommendations?cartItemIds=`; remove lógica de categorias/limites client-side. |
| #55 | US-38 | `login.html` + `js/login.js` (POST /auth/login, trata 200/400/401); ícone perfil → `login.html` em todas as páginas via handler em `api.js`. |

## Stub de sessão (escopo)

Como a **US-27 (sessão/token)** ficou com o @felipecota04, este PR entrega um **stub mínimo funcional**: \`ensureSession()\` em \`api.js\` chama \`POST /api/v1/users\` quando não há token (necessário porque \`carts.user_id\` é FK para \`users.id\` — Bearer aleatório local quebra com FK constraint). Mantém apelido \"stub\" por não decodificar JWT — a US-27 substituirá por um \`SessionService\` formal.

## Fix de bootstrap (descoberto durante o teste)

\`backend/src/db/seeds/seed_users.js\` ainda chamava \`require('../connection')\` mesmo após PR #47 ter renomeado o arquivo para \`index.js\` (PRs #47 e #48 não conflitaram porque mexem em arquivos diferentes, mas o merge order deixou o seed quebrado na main). Corrigido neste PR — \`npm run db:seed:users\` volta a rodar.

## Como rodar

\`\`\`bash
cd backend && npm install && npm run db:migrate && npm run db:seed:products && npm run db:seed:users
PORT=3001 npm start

cd frontend && python3 -m http.server 8080
# abrir http://localhost:8080/
\`\`\`

## Test plan

Backend smoke (\`PORT=3011\`):

- [x] \`GET /products\` → 200 com \`{products, total}\`
- [x] \`GET /products/1\` → 200 com objeto produto
- [x] \`GET /products/featured\` → 200 com \`{products, total}\`
- [x] \`POST /coupons/validate\` \`{code:\"BULBE10\"}\` → 200 \`{valid:true, discountPercentage:0.1}\`
- [x] \`POST /coupons/validate\` \`{code:\"NOPE\"}\` → 200 \`{valid:false}\`
- [x] \`POST /users\` → 201 \`{userId, token, createdAt}\` (stub de sessão)
- [x] \`POST /cart/items\` \`{productId:1, quantity:2}\` com Bearer → 201
- [x] \`GET /cart\` retorna item com **\`id\` (linha)** e **\`productId\`** distintos
- [x] \`PUT /cart/items/:id\` \`{quantity:5}\` → 200 com itemCount e total atualizados
- [x] \`GET /products/recommendations?cartItemIds=1\` → 200 com sugestões
- [x] \`DELETE /cart/items/:id\` e \`DELETE /cart\` → 200
- [x] \`POST /auth/login\` \`admin@bulbe.com/admin123\` → 200 com JWT + usuario
- [x] **Backend test suite** (\`npm test\` em \`backend/\`): **7/7 passando**
- [x] Sintaxe de todos os JS modificados validada (\`node --check\`)
- [ ] **Verificação UI no navegador**: não testado por mim (limitação de CLI) — recomendado validar manualmente o fluxo home → detalhe → carrinho → cupom → login

Closes #49
Closes #50
Closes #51
Closes #52
Closes #53
Closes #54
Closes #55