### PR TITLE
feat(fe): redesign responsivo e design tokens da webshop

### DIFF
--- a/frontend/css/base.css
+++ b/frontend/css/base.css
@@ -1,32 +1,127 @@
-* {
+/* ============================================================
+   Bulbe Shop — base / design system
+   Tokens, app-frame, header, navegacao, botoes e componentes
+   compartilhados. Mobile-first, fluido de 320px ao desktop.
+   ============================================================ */
+
+:root {
+    /* Marca */
+    --brand: #08068D;
+    --brand-700: #070577;
+    --brand-600: #1410A8;
+    --brand-500: #2A27C0;
+    --brand-secondary: #0762C7;
+    --brand-secondary-600: #0653A8;
+
+    /* Texto */
+    --text-strong: #29333D;
+    --text: #3E4D5B;
+    --text-muted: #536679;
+    --text-faint: #8A98A8;
+    --line: #E5E8F0;
+
+    /* Superficies */
+    --surface: #FFFFFF;
+    --surface-2: #F4F5FB;
+    --surface-3: #F8F8FF;
+
+    /* Status */
+    --success-bg: #E9FBF2;
+    --success-fg: #18814D;
+    --danger-bg: #FEE4E2;
+    --danger-fg: #B42318;
+    --gold: #FFD74A;
+
+    /* Raios */
+    --radius-sm: 8px;
+    --radius: 12px;
+    --radius-lg: 16px;
+    --radius-xl: 22px;
+    --radius-pill: 999px;
+
+    /* Sombras (suaves, em camadas) */
+    --shadow-xs: 0 1px 2px rgba(16, 24, 40, 0.06);
+    --shadow-sm: 0 2px 6px rgba(16, 24, 40, 0.07), 0 1px 2px rgba(16, 24, 40, 0.04);
+    --shadow-soft: 0 6px 18px rgba(8, 6, 141, 0.08), 0 2px 6px rgba(16, 24, 40, 0.05);
+    --shadow-md: 0 10px 26px rgba(8, 6, 141, 0.10), 0 3px 8px rgba(16, 24, 40, 0.06);
+    --shadow-lg: 0 24px 50px rgba(8, 6, 141, 0.18), 0 8px 18px rgba(16, 24, 40, 0.08);
+
+    --transition: 180ms cubic-bezier(0.4, 0, 0.2, 1);
+
+    /* Largura do "app". Antes era 393px fixo; agora vira token. */
+    --app-width: 440px;
+}
+
+*,
+*::before,
+*::after {
     margin: 0;
     padding: 0;
     box-sizing: border-box;
 }
 
+html {
+    min-height: 100%;
+    /* Fundo ambiente: aparece nas laterais quando a tela e' maior que o app */
+    background:
+        radial-gradient(900px 520px at 15% -10%, rgba(7, 98, 199, 0.12), transparent 60%),
+        radial-gradient(820px 520px at 92% 0%, rgba(8, 6, 141, 0.12), transparent 55%),
+        linear-gradient(180deg, #EEF1FB 0%, #E7EBF7 100%);
+    background-attachment: fixed;
+}
+
 body {
-    font-family: 'Poppins', sans-serif;
-    background-color: #08068D;
+    font-family: 'Poppins', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background-color: var(--brand);
+    color: var(--text);
     width: 100%;
-    max-width: 393px;
+    max-width: var(--app-width);
     margin: 0 auto;
     min-height: 100vh;
+    position: relative;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
 }
+
+/* Em telas maiores o app vira um cartao centralizado sobre o fundo ambiente */
+@media (min-width: 480px) {
+    body {
+        box-shadow: var(--shadow-lg);
+    }
+}
+
+img {
+    max-width: 100%;
+}
+
+a {
+    color: inherit;
+}
+
+:focus-visible {
+    outline: 2px solid var(--brand-secondary);
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
+/* ===================== Header ===================== */
 
 .site-header {
     width: 100%;
-    max-width: 393px;
-    height: 117px;
-    background: #08068D;
+    max-width: var(--app-width);
+    min-height: 117px;
+    background:
+        radial-gradient(120% 140% at 0% 0%, #0B09A6 0%, var(--brand) 52%, var(--brand-700) 100%);
     position: relative;
+    z-index: 10;
 }
 
 .navbar-superior {
     display: flex;
-    justify-content: center;
+    justify-content: space-between;
     align-items: center;
-    padding: 0 1px;
-    gap: 45px;
+    padding: 0 18px;
+    gap: 14px;
     width: 100%;
     height: 70px;
 }
@@ -35,14 +130,20 @@ body {
 .back-btn {
     width: 28px;
     height: 28px;
-    font-family: 'Font Awesome 5 Pro';
-    font-weight: 300;
     font-size: 24px;
     line-height: 120%;
     color: #FFFFFF;
     background: none;
     border: none;
     cursor: pointer;
+    border-radius: var(--radius-sm);
+    flex-shrink: 0;
+    transition: opacity var(--transition);
+}
+
+.menu-btn:hover,
+.back-btn:hover {
+    opacity: 0.8;
 }
 
 .menu-btn img,
@@ -52,85 +153,117 @@ body {
     object-fit: contain;
 }
 
-.bulbeshop{
-    width: 160px;
+.bulbeshop {
+    display: inline-flex;
+    align-items: center;
     height: 28px;
+    margin: 0 auto;
 }
 
 .logo {
     width: 160px;
     height: 28px;
+    object-fit: contain;
 }
 
 .profile-photo {
-    width: 28px;
-    height: 28px;
-    background: url('../images/profile.jpg');
-    border: 2px solid #FFFFFF;
-    border-radius: 200px;
+    width: 32px;
+    height: 32px;
+    background: rgba(255, 255, 255, 0.12);
+    border: 2px solid rgba(255, 255, 255, 0.85);
+    border-radius: var(--radius-pill);
+    overflow: hidden;
     display: flex;
     justify-content: center;
     align-items: center;
-    padding: 4px 0 0;
+    flex-shrink: 0;
+    cursor: pointer;
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.profile-photo:hover {
+    transform: scale(1.05);
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.18);
 }
 
 .search-bar {
     display: flex;
-    align-items: flex-start;
-    padding: 8px 12px;
+    align-items: center;
+    padding: 9px 14px;
     gap: 12px;
-    width: 374px;
-    height: 37px;
-    background: #FFFFFF;
-    border: 0.5px solid #A4B3C1;
-    border-radius: 20px;
-    margin: 0 auto;
+    height: 40px;
+    background: var(--surface);
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    border-radius: var(--radius-pill);
     position: absolute;
-    left: 9px;
-    bottom: 16px;
+    left: 16px;
+    right: 16px;
+    bottom: 14px;
+    box-shadow: var(--shadow-sm);
+    transition: box-shadow var(--transition);
+}
+
+.search-bar:focus-within {
+    box-shadow: 0 0 0 3px rgba(7, 98, 199, 0.18), var(--shadow-sm);
 }
 
 .search-bar input {
+    flex: 1;
     width: 100%;
-    height: 18px;
-    font-family: 'Poppins';
-    font-weight: 300;
+    height: 20px;
+    font-family: inherit;
+    font-weight: 400;
     font-size: 13px;
     line-height: 140%;
-    color: #A4B3C1;
+    color: var(--text);
     border: none;
     outline: none;
+    background: transparent;
+}
+
+.search-bar input::placeholder {
+    color: var(--text-faint);
 }
 
 .search-icon {
-    width: 21px;
-    height: 21px;
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    opacity: 0.85;
 }
+
+/* ===================== Conteudo ===================== */
 
 .container {
     width: 100%;
-    max-width: 393px;
-    background: #F8F8FF;
-    border-radius: 20px 20px 0 0;
-    padding: 12px 20px 35px;
-    min-height: calc(100vh - 146px);
+    max-width: var(--app-width);
+    background: var(--surface-3);
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+    padding: 16px 20px 35px;
+    min-height: calc(100vh - 117px);
+    position: relative;
 }
 
 .has-bottom-nav .container {
-    padding-bottom: 40px;
+    padding-bottom: 96px;
 }
+
+/* ===================== Bottom nav ===================== */
 
 .bottom-nav {
     display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    padding: 0 20px;
-    gap: 21px;
+    justify-content: space-around;
+    align-items: stretch;
+    padding: 0 16px;
+    gap: 8px;
     width: 100%;
-    max-width: 393px;
-    height: 80px;
-    background: #FFFFFF;
-    box-shadow: -2px -2px 8px rgba(0, 0, 0, 0.1);
+    max-width: var(--app-width);
+    height: 76px;
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: saturate(160%) blur(12px);
+    -webkit-backdrop-filter: saturate(160%) blur(12px);
+    border-top: 1px solid var(--line);
+    box-shadow: 0 -6px 20px rgba(8, 6, 141, 0.08);
     position: fixed;
     bottom: 0;
     left: 50%;
@@ -143,54 +276,30 @@ body {
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    padding: 8px 0;
-    gap: 4px;
-    width: 96px;
-    height: 80px;
+    padding: 10px 0;
+    gap: 5px;
+    flex: 1;
     text-decoration: none;
+    border-radius: var(--radius);
+    transition: background var(--transition);
+}
+
+.nav-item:hover {
+    background: var(--surface-2);
 }
 
 .nav-icon {
-    width: 20px;
-    height: 20px;
+    width: 22px;
+    height: 22px;
+    transition: transform var(--transition);
+}
+
+.nav-item.active .nav-icon {
+    transform: translateY(-1px);
 }
 
 .nav-icon.active-icon {
     display: none;
-}
-
-.product-card--alexa {
-    background: linear-gradient(180deg, #FFFBE6 0%, #FFFFFF 100%);
-    border: 1px solid rgba(255, 215, 0, 0.4);
-    box-shadow: 0 8px 18px rgba(10, 10, 10, 0.15);
-    position: relative;
-}
-
-.product-card--alexa::before {
-    content: 'Black Friday';
-    position: absolute;
-    top: -10px;
-    left: 12px;
-    background: #111111;
-    color: #FFD74A;
-    font-family: 'Poppins';
-    font-weight: 600;
-    font-size: 10px;
-    letter-spacing: 0.1em;
-    padding: 3px 10px;
-    border-radius: 999px;
-    text-transform: uppercase;
-}
-
-.product-card--alexa .discount-tag {
-    background: #111111;
-    color: #FFD74A;
-    box-shadow: 0 4px 12px rgba(17, 17, 17, 0.2);
-}
-
-.product-card--alexa .price-currency,
-.product-card--alexa .price-value {
-    color: #1C1C1C;
 }
 
 .nav-icon.inactive-icon {
@@ -206,52 +315,120 @@ body {
 }
 
 .nav-label {
-    font-family: 'Poppins';
+    font-family: inherit;
     font-weight: 500;
     font-size: 12px;
-    line-height: 18px;
+    line-height: 16px;
     text-align: center;
-    color: #C2CCD6;
+    color: var(--text-faint);
+    transition: color var(--transition);
 }
 
 .nav-item.active .nav-label {
-    color: #08068D;
+    color: var(--brand);
+    font-weight: 600;
 }
 
+/* ===================== Cartao destaque (Alexa / BF) ===================== */
+
+.product-card--alexa {
+    background: linear-gradient(180deg, #FFFBE6 0%, #FFFFFF 100%);
+    border: 1px solid rgba(255, 215, 0, 0.45);
+    box-shadow: var(--shadow-md);
+    position: relative;
+}
+
+.product-card--alexa::before {
+    content: 'Black Friday';
+    position: absolute;
+    top: -10px;
+    left: 12px;
+    background: #111111;
+    color: var(--gold);
+    font-weight: 600;
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    padding: 4px 10px;
+    border-radius: var(--radius-pill);
+    text-transform: uppercase;
+    box-shadow: var(--shadow-sm);
+}
+
+.product-card--alexa .discount-tag {
+    background: #111111;
+    color: var(--gold);
+    box-shadow: 0 4px 12px rgba(17, 17, 17, 0.2);
+}
+
+.product-card--alexa .price-currency,
+.product-card--alexa .price-value {
+    color: #1C1C1C;
+}
+
+/* ===================== Botoes ===================== */
+
 .btn {
-    display: flex;
+    display: inline-flex;
     justify-content: center;
     align-items: center;
-    padding: 3px 16px;
-    gap: 10px;
-    border-radius: 6px;
-    font-family: 'Poppins';
+    padding: 12px 18px;
+    gap: 8px;
+    border-radius: var(--radius);
+    font-family: inherit;
     font-weight: 600;
     font-size: 16px;
     line-height: 24px;
     cursor: pointer;
     border: none;
+    text-decoration: none;
+    transition: transform var(--transition), box-shadow var(--transition), filter var(--transition);
+}
+
+.btn:active {
+    transform: translateY(1px);
 }
 
 .btn-primary {
-    background: #08068D;
+    background: linear-gradient(135deg, var(--brand) 0%, #1B18B8 100%);
     color: #FFFFFF;
+    box-shadow: var(--shadow-soft);
+}
+
+.btn-primary:hover {
+    filter: brightness(1.08);
+    box-shadow: var(--shadow-md);
 }
 
 .btn-secondary {
-    background: #0762C7;
+    background: linear-gradient(135deg, var(--brand-secondary) 0%, #0A77E0 100%);
     color: #FFFFFF;
+    box-shadow: var(--shadow-soft);
 }
 
+.btn-secondary:hover {
+    filter: brightness(1.08);
+    box-shadow: var(--shadow-md);
+}
+
+.btn:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+    box-shadow: none;
+    filter: none;
+}
+
+/* ===================== Sidebar (menu sanduiche) ===================== */
+
 .sidebar-menu {
-    position: absolute;
+    position: fixed;
     top: 0;
-    left: 0;
-    width: 280px;
+    left: 50%;
+    margin-left: calc(var(--app-width) / -2);
+    width: min(280px, 82%);
     height: 100vh;
-    background-color: #070577;
+    background: linear-gradient(180deg, var(--brand-700) 0%, #050455 100%);
     border-right: 1px solid rgba(255, 255, 255, 0.1);
-    box-shadow: 6px 0 20px rgba(0, 0, 0, 0.25);
+    box-shadow: 12px 0 36px rgba(0, 0, 0, 0.3);
     transform: translateX(-100%);
     opacity: 0;
     visibility: hidden;
@@ -260,7 +437,7 @@ body {
     z-index: 2000;
     display: flex;
     flex-direction: column;
-    padding: 24px 20px;
+    padding: 26px 20px;
 }
 
 .top-sidebar-menu {
@@ -278,28 +455,28 @@ body {
 }
 
 .menu-links {
-    margin-top: 40px;
+    margin-top: 36px;
     display: flex;
     flex-direction: column;
-    gap: 12px;
+    gap: 10px;
 }
 
 .menu-link-item {
     display: block;
-    padding: 12px 14px;
-    border-radius: 12px;
+    padding: 13px 15px;
+    border-radius: var(--radius);
     text-decoration: none;
     font-size: 1rem;
     font-weight: 500;
     color: #FFFFFF;
-    background: rgba(255, 255, 255, 0.04);
+    background: rgba(255, 255, 255, 0.05);
     border: 1px solid rgba(255, 255, 255, 0.1);
-    transition: background 0.2s ease, transform 0.2s ease;
+    transition: background var(--transition), transform var(--transition);
 }
 
 .menu-link-item:hover {
-    background: rgba(255, 255, 255, 0.12);
-    transform: translateX(2px);
+    background: rgba(255, 255, 255, 0.14);
+    transform: translateX(3px);
 }
 
 .menu-bottom-actions {
@@ -314,22 +491,23 @@ body {
     align-items: center;
     justify-content: center;
     padding: 12px 0;
-    border-radius: 12px;
+    border-radius: var(--radius);
     font-weight: 600;
     font-size: 0.95rem;
     text-decoration: none;
     border: none;
     cursor: pointer;
-    transition: opacity 0.2s ease;
+    transition: opacity var(--transition), transform var(--transition);
 }
 
 .menu-cta:hover {
-    opacity: 0.85;
+    opacity: 0.9;
+    transform: translateY(-1px);
 }
 
 .contact-link {
     background: #FFFFFF;
-    color: #070577;
+    color: var(--brand-700);
 }
 
 .settings-btn {
@@ -365,6 +543,8 @@ body {
     pointer-events: auto;
 }
 
+/* ===================== Filtro (modal) ===================== */
+
 .filter-modal-overlay {
     position: fixed;
     inset: 0;
@@ -389,11 +569,11 @@ body {
     bottom: 0;
     transform: translate(-50%, 100%);
     width: 100%;
-    max-width: 393px;
-    background: #FFFFFF;
-    border-radius: 24px 24px 0 0;
-    box-shadow: 0 -10px 25px rgba(0, 0, 0, 0.2);
-    padding: 20px 20px 28px;
+    max-width: var(--app-width);
+    background: var(--surface);
+    border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+    box-shadow: 0 -12px 32px rgba(8, 6, 141, 0.22);
+    padding: 22px 20px 28px;
     z-index: 1500;
     transition: transform 0.3s ease;
 }
@@ -411,26 +591,38 @@ body {
 
 .filter-modal__title {
     font-size: 1.2rem;
-    color: #08068D;
+    color: var(--brand);
 }
 
 .filter-modal__close {
-    background: none;
+    background: var(--surface-2);
     border: none;
-    font-size: 1.8rem;
+    width: 34px;
+    height: 34px;
+    border-radius: var(--radius-pill);
+    font-size: 1.5rem;
     line-height: 1;
     cursor: pointer;
-    color: #08068D;
+    color: var(--brand);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background var(--transition);
+}
+
+.filter-modal__close:hover {
+    background: #E6E9F5;
 }
 
 .filter-modal__section {
-    margin-bottom: 16px;
+    margin-bottom: 18px;
 }
 
 .filter-modal__section-title {
     font-size: 0.95rem;
-    color: #536679;
-    margin-bottom: 8px;
+    font-weight: 600;
+    color: var(--text-muted);
+    margin-bottom: 10px;
 }
 
 .filter-options {
@@ -443,23 +635,39 @@ body {
     display: flex;
     align-items: center;
     gap: 6px;
-    padding: 8px 12px;
-    border-radius: 12px;
-    background: #F4F5FB;
+    padding: 9px 13px;
+    border-radius: var(--radius);
+    background: var(--surface-2);
+    border: 1px solid transparent;
     font-size: 0.9rem;
     color: #0A0A33;
+    cursor: pointer;
+    transition: background var(--transition), border-color var(--transition);
+}
+
+.filter-option:hover {
+    background: #ECEFFA;
+}
+
+.filter-option:has(input:checked) {
+    background: #E6F1FE;
+    border-color: var(--brand-secondary);
+}
+
+.filter-option input {
+    accent-color: var(--brand);
 }
 
 .filter-modal__actions {
     display: flex;
     gap: 12px;
-    margin-top: 12px;
+    margin-top: 16px;
 }
 
 .filter-modal__actions .btn-primary,
 .filter-modal__actions .btn-secondary {
     flex: 1;
-    border-radius: 18px;
+    border-radius: var(--radius-lg);
     padding: 14px 0;
     font-size: 1rem;
 }
@@ -468,42 +676,86 @@ body.filter-modal-open {
     overflow: hidden;
 }
 
-.product-card .product-image {
-    width: 100%;
-    height: 160px;
-    border-radius: 12px;
-    background: #F4F5FB;
-    object-fit: contain;
-    padding: 8px;
-    display: block;
-    margin-bottom: 8px;
+.filter-clear-btn {
+    background: rgba(8, 6, 141, 0.07);
+    color: var(--brand);
+    border: 1px solid rgba(8, 6, 141, 0.15);
+    box-shadow: none;
 }
 
-.filter-clear-btn {
-    background: rgba(8, 6, 141, 0.08);
-    color: #08068D;
-    border: 1px solid rgba(8, 6, 141, 0.15);
+.filter-clear-btn:hover {
+    background: rgba(8, 6, 141, 0.12);
+    filter: none;
 }
 
 .filter-apply-btn {
-    background: #08068D;
+    background: linear-gradient(135deg, var(--brand) 0%, #1B18B8 100%);
     color: #FFFFFF;
     border: none;
 }
 
+/* ===================== Cartao de produto (base unificada) ===================== */
+
+.product-card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-soft);
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.product-card:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-md);
+}
+
+.product-card .product-image {
+    width: 100%;
+    height: 160px;
+    border-radius: var(--radius);
+    background: var(--surface-2);
+    object-fit: contain;
+    padding: 10px;
+    display: block;
+    margin-bottom: 8px;
+}
+
+/* Preco do card escala com a largura para nunca estourar a coluna estreita */
+.product-card .price-value {
+    font-size: clamp(22px, 6.4vw, 34px);
+}
+
+/* ===================== Tipografia utilitaria ===================== */
+
 .page-title {
-    font-family: 'Poppins';
-    font-weight: 500;
+    font-family: inherit;
+    font-weight: 600;
     font-size: 23px;
-    line-height: 140%;
-    color: #08068D;
+    line-height: 132%;
+    letter-spacing: -0.01em;
+    color: var(--brand);
 }
 
 .section-title {
-    font-family: 'Poppins';
-    font-weight: 400;
+    font-family: inherit;
+    font-weight: 600;
     font-size: 14px;
     line-height: 20px;
-    color: #536679;
-    margin-bottom: 10px;
+    color: var(--text-muted);
+    margin-bottom: 12px;
+    letter-spacing: 0.01em;
+}
+
+/* ===================== Responsivo: tablet / desktop ===================== */
+/* A partir de ~600px o "app" ganha largura e as grades de produto passam a
+   3 colunas, aproveitando melhor a tela sem perder a identidade mobile. */
+@media (min-width: 600px) {
+    :root {
+        --app-width: 600px;
+    }
+
+    .container .products-grid,
+    .container .product-grid-horizontal {
+        grid-template-columns: repeat(3, 1fr);
+    }
 }

--- a/frontend/css/black-friday.css
+++ b/frontend/css/black-friday.css
@@ -2,6 +2,10 @@
     background: #FFFBE6;
 }
 
+.black-friday-page .container {
+    background: linear-gradient(180deg, #FFFDF2 0%, #FFFFFF 100%);
+}
+
 .black-friday-page .page-header {
     flex-direction: row;
     align-items: flex-start;
@@ -14,6 +18,7 @@
     display: flex;
     flex-direction: column;
     gap: 4px;
+    min-width: 0;
 }
 
 .black-friday-eyebrow {
@@ -56,7 +61,7 @@
 .product-card--black-friday {
     background: linear-gradient(180deg, #FFFBE6 0%, #FFFFFF 100%);
     border: 1px solid rgba(0, 0, 0, 0.08);
-    box-shadow: 0px 20px 40px rgba(15, 15, 15, 0.15);
+    box-shadow: var(--shadow-md);
     position: relative;
 }
 
@@ -96,4 +101,5 @@
     font-family: 'Poppins';
     font-weight: 500;
     color: #4E3F15;
+    overflow-wrap: anywhere;
 }

--- a/frontend/css/cart.css
+++ b/frontend/css/cart.css
@@ -21,19 +21,22 @@
     flex-direction: column;
     justify-content: center;
     align-items: flex-start;
-    padding: 16px 10px;
-    gap: 2px;
+    padding: 16px 14px;
+    gap: 4px;
     background: #FFFFFF;
-    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-    border-radius: 8px;
+    border: 1px solid var(--line);
+    box-shadow: var(--shadow-soft);
+    border-radius: var(--radius-lg);
 }
 
 .item-image-container {
-    width: 135.5px;
-    height: 135.5px;
-    border-radius: 8px;
+    width: 128px;
+    height: 128px;
+    border-radius: var(--radius);
     overflow: hidden;
-    box-shadow: 1px 4px 4px rgba(0, 0, 0, 0.25);
+    background: var(--surface-2);
+    border: 1px solid var(--line);
+    box-shadow: var(--shadow-xs);
     flex-shrink: 0;
 }
 
@@ -59,6 +62,7 @@
     padding: 10px 0px 0px;
     gap: 3px;
     flex: 1;
+    min-width: 0;
 }
 
 .item-title {
@@ -156,39 +160,51 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-    padding: 0px 60px;
+    gap: 8px;
+    margin-top: 8px;
+    padding: 6px 10px;
     width: 100%;
-    height: 24px;
-    filter: drop-shadow(0px 1px 4px rgba(0, 0, 0, 0.25));
+    max-width: 190px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-pill);
+    box-shadow: var(--shadow-xs);
 }
 
 .quantity-btn {
     font-family: 'Poppins';
-    font-style: italic;
     font-weight: 600;
     font-size: 20px;
-    line-height: 24px;
+    line-height: 1;
     text-align: center;
-    color: #08068D;
-    background: none;
+    color: var(--brand);
+    background: var(--surface-2);
     border: none;
     cursor: pointer;
     padding: 0;
-    margin: 0 auto;
+    margin: 0;
+    width: 30px;
+    height: 30px;
+    border-radius: var(--radius-pill);
+    flex-shrink: 0;
+    transition: background var(--transition);
+}
+
+.quantity-btn:hover {
+    background: #E2E6F3;
 }
 
 .quantity-input {
     font-family: 'Poppins';
-    font-style: italic;
     font-weight: 600;
-    font-size: 20px;
+    font-size: 18px;
     line-height: 24px;
     text-align: center;
-    color: #08068D;
+    color: var(--brand);
     border: none;
     background: transparent;
-    width: 40px;
-    margin: 0 auto;
+    width: 44px;
+    margin: 0;
     -moz-appearance: textfield;
 }
 
@@ -244,9 +260,9 @@
     bottom: 16px;
     transform: translateX(-50%);
     width: calc(100% - 32px);
-    height: 60px;
-    border-radius: 20px;
-    background: #08068D;
+    height: 58px;
+    border-radius: var(--radius-lg);
+    background: linear-gradient(135deg, var(--brand) 0%, #1B18B8 100%);
     color: #FFFFFF;
     font-family: 'Poppins';
     font-weight: 700;
@@ -256,6 +272,17 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    box-shadow: var(--shadow-md);
+    transition: filter var(--transition), box-shadow var(--transition), transform var(--transition);
+}
+
+.checkout-fab:hover {
+    filter: brightness(1.08);
+    box-shadow: var(--shadow-lg);
+}
+
+.checkout-fab:active {
+    transform: translateX(-50%) translateY(1px);
 }
 
 /* Espaço extra para o footer fixo */
@@ -305,17 +332,22 @@
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
-    height: 32px;
-    width: 32px;
-    border-radius: 16px;
+    height: 34px;
+    width: 34px;
+    border-radius: var(--radius-pill);
     border: none;
-    background: #08068D;
+    background: var(--brand);
     color: #FFFFFF;
     font-family: 'Poppins';
     font-weight: 600;
     cursor: pointer;
     z-index: 2;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.15);
+    box-shadow: var(--shadow-md);
+    transition: filter var(--transition);
+}
+
+.carousel-btn:hover {
+    filter: brightness(1.12);
 }
 
 .carousel-btn.prev {

--- a/frontend/css/catalog.css
+++ b/frontend/css/catalog.css
@@ -8,13 +8,20 @@
 .category-banner {
     position: relative;
     width: 100%;
-    height: 210px;
-    border-radius: 13px;
+    height: 200px;
+    border-radius: var(--radius-lg);
     overflow: hidden;
     text-decoration: none;
     display: flex;
     align-items: center;
     justify-content: center;
+    box-shadow: var(--shadow-soft);
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.category-banner:hover {
+    transform: translateY(-3px);
+    box-shadow: var(--shadow-md);
 }
 
 .banner-image {
@@ -24,6 +31,11 @@
     position: absolute;
     top: 0;
     left: 0;
+    transition: transform 400ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.category-banner:hover .banner-image {
+    transform: scale(1.04);
 }
 
 .banner-title {

--- a/frontend/css/checkout.css
+++ b/frontend/css/checkout.css
@@ -44,9 +44,10 @@
     font-weight: 600;
     font-size: 14px;
     line-height: 140%;
-    color: #3E4D5B;
+    color: var(--text);
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: 4px;
 }
 
@@ -62,27 +63,29 @@
 .form-input,
 .form-select {
     font-family: 'Poppins';
-    font-weight: 300;
+    font-weight: 400;
     font-size: 16px;
     line-height: 140%;
-    letter-spacing: 0.02em;
-    color: #3E4D5B;
+    letter-spacing: 0.01em;
+    color: var(--text);
     background: #FFFFFF;
-    border: 0.5px solid #A4B3C1;
-    border-radius: 8px;
-    padding: 12px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius-sm);
+    padding: 12px 14px;
     width: 100%;
     box-sizing: border-box;
+    transition: border-color var(--transition), box-shadow var(--transition);
 }
 
 .form-input::placeholder {
-    color: #A4B3C1;
+    color: var(--text-faint);
 }
 
 .form-input:focus,
 .form-select:focus {
     outline: none;
-    border-color: #08068D;
+    border-color: var(--brand);
+    box-shadow: 0 0 0 3px rgba(8, 6, 141, 0.12);
 }
 
 .form-select {
@@ -102,18 +105,27 @@
 .payment-option {
     display: flex;
     align-items: center;
-    gap: 8px;
-    padding: 12px;
+    gap: 10px;
+    padding: 14px;
     background: #FFFFFF;
-    border: 1px solid #A4B3C1;
-    border-radius: 8px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
     cursor: pointer;
-    transition: all 0.2s;
+    transition: border-color var(--transition), background var(--transition), box-shadow var(--transition);
+}
+
+.payment-option:hover {
+    border-color: var(--brand-secondary);
+}
+
+.payment-option input[type="radio"] {
+    accent-color: var(--brand);
 }
 
 .payment-option:has(input:checked) {
-    border-color: #08068D;
-    background: #F8F8FF;
+    border-color: var(--brand);
+    background: var(--surface-3);
+    box-shadow: 0 0 0 1px var(--brand) inset;
 }
 
 .payment-option input[type="radio"] {
@@ -171,36 +183,38 @@
 
 .submit-btn {
     width: 100%;
-    height: 44px;
+    min-height: 52px;
     margin-top: 16px;
-}
-
-body{
-    background-color: #08068D; /* Preenche a quina de azul*/
 }
 
 .row-cupom{
     display: flex;
     gap: 8px;
-    justify-content: space-between;
+    align-items: stretch;
     position: relative;
 }
 
 #cupom-desconto{
-    width: 278px
+    flex: 1;
+    min-width: 0;
 }
 
 #ok-cupom{
-    font-size: 1.125rem;
+    font-size: 1rem;
     font-weight: 700;
     color: #FFFFFF;
-    background-color: #08068D;
+    background: linear-gradient(135deg, var(--brand) 0%, #1B18B8 100%);
     border: none;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     cursor: pointer;
     font-family: 'Poppins';
-    transition: background-color 0.2s ease;
-    width: 64px;
+    transition: filter var(--transition);
+    width: 72px;
+    flex-shrink: 0;
+}
+
+#ok-cupom:hover{
+    filter: brightness(1.1);
 }
 
 .feedback-cupom{

--- a/frontend/css/confirmation.css
+++ b/frontend/css/confirmation.css
@@ -2,7 +2,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    min-height: calc(100vh - 146px);
+    min-height: calc(100vh - 117px);
     padding-bottom: 40px;
 }
 
@@ -10,9 +10,15 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 32px;
+    gap: 24px;
     text-align: center;
     max-width: 320px;
+    width: 100%;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-soft);
+    padding: 40px 28px;
 }
 
 .page-title {
@@ -45,8 +51,7 @@
 
 .return-btn {
     width: 100%;
-    height: 44px;
-    padding: 16px 10px;
+    min-height: 50px;
     text-decoration: none;
     display: flex;
     align-items: center;

--- a/frontend/css/index.css
+++ b/frontend/css/index.css
@@ -18,8 +18,17 @@
 .hero-image {
     width: 100%;
     height: auto;
-    border-radius: 20px;
+    border-radius: var(--radius-xl);
     display: block;
+    box-shadow: var(--shadow-soft);
+}
+
+.hero-banner-link {
+    transition: transform var(--transition);
+}
+
+.hero-banner-link:hover {
+    transform: translateY(-2px);
 }
 
 .categories-section {
@@ -47,16 +56,22 @@
 }
 
 .category-icon {
-    width: 58px;
-    height: 57px;
-    border-radius: 100px;
+    width: 60px;
+    height: 60px;
+    border-radius: var(--radius-pill);
     overflow: hidden;
     border: 2px solid #FFFFFF;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    background-color: #2D5BA0;
+    box-shadow: var(--shadow-sm);
+    background: linear-gradient(145deg, var(--brand-secondary) 0%, var(--brand) 100%);
     display: flex;
     align-items: center;
     justify-content: center;
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.category-item:hover .category-icon {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-soft);
 }
 
 .category-icon img {
@@ -67,11 +82,11 @@
 
 .category-name {
     font-family: 'Poppins';
-    font-weight: 400;
+    font-weight: 500;
     font-size: 12px;
     line-height: 18px;
     text-align: center;
-    color: #3E4D5B;
+    color: var(--text-strong);
 }
 
 .product-showcase {
@@ -86,14 +101,12 @@
 }
 
 .product-card {
-    background: #FFFFFF;
-    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-    border-radius: 8px;
-    padding: 10px;
+    padding: 12px;
     position: relative;
     display: flex;
     flex-direction: column;
     height: 100%;
+    cursor: pointer;
 }
 
 .product-image {

--- a/frontend/css/product-detail.css
+++ b/frontend/css/product-detail.css
@@ -21,8 +21,9 @@
     width: 100%;
     height: 333px;
     background: #FFFFFF;
-    border-radius: 8px;
-    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    border: 1px solid var(--line);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-soft);
     overflow: hidden;
     margin-bottom: 12px;
 }
@@ -79,17 +80,22 @@
     width: 65px;
     height: 65px;
     background: #FFFFFF;
-    border-radius: 8px;
-    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-sm);
     border: 2px solid transparent;
     cursor: pointer;
     overflow: hidden;
     padding: 0;
-    transition: border-color 0.3s;
+    transition: border-color var(--transition), transform var(--transition), box-shadow var(--transition);
+}
+
+.thumbnail:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-soft);
 }
 
 .thumbnail.active {
-    border-color: #0762C7;
+    border-color: var(--brand-secondary);
 }
 
 .thumbnail img {
@@ -217,12 +223,12 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 12px;
+    padding: 10px 12px;
     background: #FFFFFF;
-    border: 1px solid #D1D9E0;
-    border-radius: 8px;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
     min-width: 120px;
-    box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.25);
+    box-shadow: var(--shadow-xs);
 }
 
 .quantity-btn {

--- a/frontend/css/product-list.css
+++ b/frontend/css/product-list.css
@@ -20,15 +20,23 @@
 
 .filter-btn {
     background: #E6F1FE;
-    border-radius: 12px;
-    padding: 4px 12px;
+    border-radius: var(--radius-pill);
+    padding: 8px 16px;
     font-family: 'Poppins';
     font-weight: 600;
     font-size: 13px;
     line-height: 20px;
-    color: #08068D;
-    border: none;
+    color: var(--brand);
+    border: 1px solid rgba(8, 6, 141, 0.08);
     cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
+    transition: background var(--transition), transform var(--transition);
+}
+
+.filter-btn:hover {
+    background: #D9E8FD;
+    transform: translateY(-1px);
 }
 
 .products-grid {
@@ -39,10 +47,7 @@
 }
 
 .product-card {
-    background: #FFFFFF;
-    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
-    border-radius: 12px;
-    padding: 8px;
+    padding: 12px;
     position: relative;
     display: flex;
     flex-direction: column;

--- a/frontend/css/search-results.css
+++ b/frontend/css/search-results.css
@@ -20,15 +20,23 @@
 
 .filter-btn {
     background: #E6F1FE;
-    border-radius: 8px;
-    padding: 4px 12px;
+    border-radius: var(--radius-pill);
+    padding: 8px 16px;
     font-family: 'Poppins';
     font-weight: 600;
     font-size: 13px;
     line-height: 20px;
-    color: #08068D;
-    border: none;
+    color: var(--brand);
+    border: 1px solid rgba(8, 6, 141, 0.08);
     cursor: pointer;
+    white-space: nowrap;
+    flex-shrink: 0;
+    transition: background var(--transition), transform var(--transition);
+}
+
+.filter-btn:hover {
+    background: #D9E8FD;
+    transform: translateY(-1px);
 }
 
 .products-grid {
@@ -39,10 +47,7 @@
 }
 
 .product-card {
-    background: #FFFFFF;
-    box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.15);
-    border-radius: 8px;
-    padding: 10px;
+    padding: 12px;
     position: relative;
     display: flex;
     flex-direction: column;

--- a/frontend/login.html
+++ b/frontend/login.html
@@ -9,18 +9,26 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,300;0,400;0,500;0,600;1,400;1,500;1,600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/base.css">
     <style>
+        body {
+            background: var(--surface-3);
+        }
         .login-container {
-            max-width: 420px;
-            margin: 40px auto;
-            padding: 32px 24px;
+            max-width: min(400px, calc(100% - 32px));
+            margin: 32px auto;
+            padding: 34px 26px;
+            background: var(--surface);
+            border: 1px solid var(--line);
+            border-radius: var(--radius-xl);
+            box-shadow: var(--shadow-soft);
         }
         .login-title {
             font-size: 24px;
             font-weight: 600;
-            margin-bottom: 8px;
+            margin-bottom: 6px;
+            color: var(--brand);
         }
         .login-subtitle {
-            color: #666;
+            color: var(--text-muted);
             margin-bottom: 24px;
             font-size: 14px;
         }
@@ -30,39 +38,49 @@
         .login-form label {
             display: block;
             font-size: 13px;
-            font-weight: 500;
+            font-weight: 600;
             margin-bottom: 6px;
-            color: #333;
+            color: var(--text);
         }
         .login-form input {
             width: 100%;
             padding: 12px 14px;
-            border: 1px solid #ddd;
-            border-radius: 8px;
+            border: 1px solid var(--line);
+            border-radius: var(--radius-sm);
             font-family: 'Poppins', sans-serif;
             font-size: 14px;
             box-sizing: border-box;
+            transition: border-color 0.18s ease, box-shadow 0.18s ease;
         }
         .login-form input:focus {
             outline: none;
-            border-color: #f7c948;
+            border-color: var(--brand);
+            box-shadow: 0 0 0 3px rgba(8, 6, 141, 0.12);
         }
         .login-submit {
             width: 100%;
             padding: 14px;
             margin-top: 8px;
-            background: #f7c948;
-            color: #1a1a1a;
+            background: linear-gradient(135deg, var(--brand) 0%, #1B18B8 100%);
+            color: #FFFFFF;
             border: none;
-            border-radius: 8px;
+            border-radius: var(--radius);
             font-family: 'Poppins', sans-serif;
             font-size: 15px;
             font-weight: 600;
             cursor: pointer;
+            box-shadow: var(--shadow-soft);
+            transition: filter 0.18s ease, box-shadow 0.18s ease;
+        }
+        .login-submit:hover {
+            filter: brightness(1.08);
+            box-shadow: var(--shadow-md);
         }
         .login-submit:disabled {
             opacity: 0.6;
             cursor: not-allowed;
+            box-shadow: none;
+            filter: none;
         }
         .login-feedback {
             margin-top: 16px;
@@ -73,21 +91,27 @@
         }
         .login-feedback.error {
             display: block;
-            background: #fdecec;
-            color: #b3261e;
+            background: var(--danger-bg);
+            color: var(--danger-fg);
             border: 1px solid #f5c2c0;
         }
         .login-feedback.success {
             display: block;
-            background: #e7f6ec;
-            color: #1b5e20;
+            background: var(--success-bg);
+            color: var(--success-fg);
             border: 1px solid #b7e1c0;
         }
         .login-hint {
-            margin-top: 12px;
+            margin-top: 14px;
             font-size: 12px;
-            color: #888;
+            color: var(--text-faint);
             text-align: center;
+        }
+        .login-hint code {
+            background: var(--surface-2);
+            padding: 2px 6px;
+            border-radius: 6px;
+            color: var(--brand);
         }
     </style>
 </head>


### PR DESCRIPTION
## Resumo

Refresh visual completo do **frontend da webshop**: introduz um sistema de design coerente (tokens), deixa a interface mais bonita e **responsiva de 320px ao desktop**, e corrige o maior problema visual — no desktop o app aparecia como uma faixa estreita flutuando num **vão azul chapado**.

Mudança **somente de CSS** (+ os estilos inline do `login.html`). **Nenhum HTML estrutural ou JS foi alterado** — todos os `id`/classe/`data-*` consumidos pelo JS foram preservados, então o comportamento (carrinho, busca, filtros, checkout, galeria, etc.) continua idêntico.

## O que mudou

**`css/base.css` (coração do design system)**
- `:root` com tokens: paleta da marca, **sombras suaves em camadas**, raios, transições e `--app-width`.
- **Frame ambiente no desktop**: o app vira um cartão centralizado sobre um gradiente suave (fim do vão azul). Em mobile continua full-width como antes.
- **Larguras fluidas**: troquei os números mágicos (`393px`, `374px`, `278px`…) por `%`/`min()`/tokens — não estoura mais em telas pequenas.
- Header, barra de busca, bottom-nav, sidebar, modal de filtro e botões repaginados com estados `:hover`/`:focus-visible`.
- **Responsividade desktop**: a partir de `600px` o app ganha largura e as grades de produto passam a **3 colunas**.

**Páginas** (`index, product-list, search-results, product-detail, cart, checkout, confirmation, catalog, black-friday`)
- Sombras duras (`0 4px 4px rgba(0,0,0,.25)`) → sombras suaves via token.
- Cards de produto unificados com hover-lift; controle de quantidade do carrinho redesenhado; inputs/foco do checkout; cartão de confirmação; hover em banners e thumbnails.
- Corrigido um `var(--shadow-soft)` que estava indefinido no `cart.css` (não renderizava sombra).

**`login.html`** — alinhado ao sistema (cartão sobre superfície clara, inputs com foco da marca, CTA na cor primária indigo em vez do amarelo). *Felipe, se preferir manter o amarelo no botão, é só avisar — é um bloco isolado.*

## Não quebra nada
- Diff só em `css/*` e `login.html`.
- Contrato de DOM do JS verificado (todos os seletores `getElementById`/`querySelector`/`data-*` continuam existindo).
- HTML estrutural intacto.

## Test plan
- [x] Renderização validada com **screenshots headless (Chrome)** em **390px (mobile)** e **1280px (desktop)** nas 12 páginas.
- [x] Estados dinâmicos exercitados (grade de destaques, lista por categoria, busca, detalhe, carrinho com itens, recomendações, black friday).
- [x] Regressões corrigidas: preço estourando a coluna no mobile (clamp), botão "Filtros" colapsando na Black Friday, overflow de texto em telas estreitas, card do login extrapolando 390px.
- [ ] Conferir num device físico / janela real (recomendado antes do merge).

## Decisões / possíveis follow-ups
- Mantive a **identidade mobile-app** como experiência canônica (cartão centralizado no desktop) em vez de um layout desktop full-bleed, pra não arriscar quebrar o design feito no Figma. Um layout desktop multi-coluna mais "largo" pode ser um follow-up se o time quiser.
- Mantidos de propósito: check verde de sucesso na confirmação (convenção), tema amarelo/preto da Black Friday, banners full-bleed do catálogo.
- Fora de escopo (CSS-only): empty-state de "Meus Pedidos" é renderizado por JS; texto dos banners de categoria está embutido nas imagens.
