### PR TITLE
feat(api): isola a black-friday numa porta dedicada (bulkhead)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,25 @@ A Bulbe Energia API é o backend do sistema de monitoramento e comercialização
 
 ## ⚙️ Como Executar Localmente
 
-> *A ser preenchido na Sprint 2.*
+> Pré-requisitos: Node.js 18+ e npm.
+
+```bash
+cd backend
+npm install
+
+npm run db:migrate          # cria o schema SQLite
+npm run db:seed:products    # popula o catálogo
+npm run db:seed:users       # popula usuários de teste
+
+npm start                   # API principal     -> http://localhost:3001
+npm run start:blackfriday   # API Black Friday  -> http://localhost:3002
+```
+
+A campanha de **Black Friday roda como serviço isolado, numa porta própria**
+(`BLACK_FRIDAY_PORT`, padrão `3002`), separada da API principal (`PORT`, padrão
+`3001`). É o padrão *bulkhead*: o pico de tráfego da campanha fica contido no
+seu próprio processo e não derruba o catálogo, o carrinho nem o checkout da loja.
+Cada serviço sobe de forma independente; para a loja completa, rode os dois.
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,9 @@
 # Porta do servidor HTTP
 PORT=3001
 
+# Porta do servico isolado da Black Friday (bulkhead: processo proprio)
+BLACK_FRIDAY_PORT=3002
+
 # Caminho do arquivo SQLite (relativo ao diretorio backend/)
 DATABASE_PATH=./data/bulbe.db
 

--- a/backend/docs/openapi.yaml
+++ b/backend/docs/openapi.yaml
@@ -125,11 +125,20 @@ paths:
                     example: 8
 
   /products/black-friday:
+    servers:
+      - url: http://localhost:3002/api/v1
+        description: Serviço isolado da Black Friday (porta dedicada)
     get:
       tags: [Products]
       summary: Produtos da campanha Black Friday
       description: |
         Retorna os produtos selecionados para a campanha Black Friday.
+
+        Esta rota roda num serviço isolado, em porta própria (`BLACK_FRIDAY_PORT`,
+        padrão `3002`), separado da API principal (`PORT`, padrão `3001`). O pico
+        de tráfego da campanha fica contido no seu próprio processo e não derruba
+        o catálogo, o carrinho nem o checkout (padrão *bulkhead*).
+
         Suporta filtros opcionais por categoria, faixa de preço e avaliação mínima.
       parameters:
         - in: query

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "start": "node src/server.js",
     "dev": "node --watch src/server.js",
+    "start:blackfriday": "node src/blackFridayServer.js",
+    "dev:blackfriday": "node --watch src/blackFridayServer.js",
     "db:migrate": "node src/db/migrate.js",
     "db:seed:products": "node src/db/seeds/seed_products.js",
     "db:seed:users": "node src/db/seeds/seed_users.js",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -6,7 +6,6 @@ const swaggerUi = require('swagger-ui-express');
 const yaml = require('js-yaml');
 
 const productsRoutes = require('./routes/products.routes');
-const blackFridayRoutes = require('./routes/blackFriday.routes');
 const cartRoutes = require('./routes/cart.routes');
 const orderRoutes = require('./routes/order.routes');
 const customerRoutes = require('./routes/customer.routes');
@@ -25,8 +24,8 @@ const openapiSpec = yaml.load(
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(openapiSpec));
 app.get('/openapi.json', (_req, res) => res.json(openapiSpec));
 
-// Rota mais especifica antes de /products/:id para nao cair no getProductById.
-app.use('/api/v1/products/black-friday', blackFridayRoutes);
+// A black-friday foi isolada num app/porta proprios (ver blackFridayApp.js);
+// o app principal nao serve mais essa rota.
 app.use('/api/v1/products', productsRoutes);
 app.use('/api/v1/cart', cartRoutes);
 app.use('/api/v1/orders', orderRoutes);

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -6,6 +6,7 @@ const swaggerUi = require('swagger-ui-express');
 const yaml = require('js-yaml');
 
 const productsRoutes = require('./routes/products.routes');
+const blackFridayRoutes = require('./routes/blackFriday.routes');
 const cartRoutes = require('./routes/cart.routes');
 const orderRoutes = require('./routes/order.routes');
 const customerRoutes = require('./routes/customer.routes');
@@ -24,6 +25,8 @@ const openapiSpec = yaml.load(
 app.use('/docs', swaggerUi.serve, swaggerUi.setup(openapiSpec));
 app.get('/openapi.json', (_req, res) => res.json(openapiSpec));
 
+// Rota mais especifica antes de /products/:id para nao cair no getProductById.
+app.use('/api/v1/products/black-friday', blackFridayRoutes);
 app.use('/api/v1/products', productsRoutes);
 app.use('/api/v1/cart', cartRoutes);
 app.use('/api/v1/orders', orderRoutes);

--- a/backend/src/blackFridayApp.js
+++ b/backend/src/blackFridayApp.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const cors = require('cors');
+
+const blackFridayRoutes = require('./routes/blackFriday.routes');
+
+// App isolado da campanha de Black Friday.
+//
+// Roda como processo proprio, numa porta dedicada (BLACK_FRIDAY_PORT), para
+// que o pico de trafego da campanha nao concorra pelo event loop do app
+// principal (catalogo, carrinho, checkout). Padrao bulkhead: se a Black
+// Friday saturar, a loja continua vendendo.
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+
+app.use('/api/v1/products/black-friday', blackFridayRoutes);
+
+module.exports = app;

--- a/backend/src/blackFridayServer.js
+++ b/backend/src/blackFridayServer.js
@@ -1,0 +1,7 @@
+const app = require('./blackFridayApp');
+
+const PORT = process.env.BLACK_FRIDAY_PORT || 3002;
+
+app.listen(PORT, () => {
+    console.log(`Black Friday API rodando em http://localhost:${PORT}`);
+});

--- a/backend/src/controllers/blackFriday.controller.js
+++ b/backend/src/controllers/blackFriday.controller.js
@@ -1,0 +1,28 @@
+const blackFridayService = require('../services/blackFriday.service');
+
+// Fonte unica das faixas validas: deriva das chaves do servico.
+const VALID_PRICE_RANGES = Object.keys(blackFridayService.PRICE_RANGES);
+
+function getBlackFridayProducts(req, res) {
+    const { category, priceRange, minRating } = req.query;
+
+    if (priceRange !== undefined && !VALID_PRICE_RANGES.includes(priceRange)) {
+        return res.status(400).json({ error: 'priceRange invalido' });
+    }
+
+    const result = blackFridayService.getBlackFridayProducts({
+        category,
+        priceRange,
+        minRating,
+    });
+
+    res.status(200).json({
+        products: result.products,
+        filters: result.filters,
+        total: result.products.length,
+    });
+}
+
+module.exports = {
+    getBlackFridayProducts,
+};

--- a/backend/src/controllers/products.controller.js
+++ b/backend/src/controllers/products.controller.js
@@ -29,28 +29,6 @@ function getFeaturedProducts(req, res) {
     res.status(200).json({ products, total: products.length });
 }
 
-const VALID_PRICE_RANGES = ['all', '0-50', '50-100', '100-300', '300-999'];
-
-function getBlackFridayProducts(req, res) {
-    const { category, priceRange, minRating } = req.query;
-
-    if (priceRange !== undefined && !VALID_PRICE_RANGES.includes(priceRange)) {
-        return res.status(400).json({ error: 'priceRange invalido' });
-    }
-
-    const result = productsService.getBlackFridayProducts({
-        category,
-        priceRange,
-        minRating,
-    });
-
-    res.status(200).json({
-        products: result.products,
-        filters: result.filters,
-        total: result.products.length,
-    });
-}
-
 function getRecommendations(req, res) {
     const raw = typeof req.query.cartItemIds === 'string' ? req.query.cartItemIds : '';
     const cartItemIds = raw
@@ -104,7 +82,6 @@ module.exports = {
     getProductById,
     searchProducts,
     getFeaturedProducts,
-    getBlackFridayProducts,
     getRecommendations,
     createProduct,
     updateProduct,

--- a/backend/src/routes/blackFriday.routes.js
+++ b/backend/src/routes/blackFriday.routes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const blackFridayController = require('../controllers/blackFriday.controller');
+
+const router = express.Router();
+
+// Montado em /api/v1/products/black-friday: endpoint unico da campanha.
+router.get('/', blackFridayController.getBlackFridayProducts);
+
+module.exports = router;

--- a/backend/src/routes/products.routes.js
+++ b/backend/src/routes/products.routes.js
@@ -7,7 +7,6 @@ const router = express.Router();
 router.get('/', productsController.listProducts);
 router.get('/search', productsController.searchProducts);
 router.get('/featured', productsController.getFeaturedProducts);
-router.get('/black-friday', productsController.getBlackFridayProducts);
 router.get('/recommendations', productsController.getRecommendations);
 router.get('/:id', productsController.getProductById);
 

--- a/backend/src/services/blackFriday.service.js
+++ b/backend/src/services/blackFriday.service.js
@@ -1,0 +1,49 @@
+const repo = require('../repositories/product.repository');
+
+// Faixas de preco aceitas no filtro da campanha (label -> [min, max]).
+const PRICE_RANGES = {
+    'all': null,
+    '0-50': [0, 50],
+    '50-100': [50, 100],
+    '100-300': [100, 300],
+    '300-999': [300, 999],
+};
+
+function getBlackFridayProducts({ category, priceRange, minRating } = {}) {
+    const base = repo.findBlackFriday();
+
+    let filtered = base;
+
+    if (category) {
+        const normalized = category.trim().toLowerCase();
+        filtered = filtered.filter(
+            (p) => p.category && p.category.toLowerCase().includes(normalized)
+        );
+    }
+
+    if (priceRange && priceRange !== 'all') {
+        const range = PRICE_RANGES[priceRange];
+        if (range) {
+            const [min, max] = range;
+            filtered = filtered.filter((p) => p.price >= min && p.price <= max);
+        }
+    }
+
+    if (minRating !== undefined && minRating !== null && !Number.isNaN(Number(minRating))) {
+        const min = Number(minRating);
+        filtered = filtered.filter((p) => (p.rating || 0) >= min);
+    }
+
+    const categories = [...new Set(base.map((p) => p.category).filter(Boolean))];
+    const priceRanges = Object.keys(PRICE_RANGES).filter((k) => k !== 'all');
+
+    return {
+        products: filtered,
+        filters: { categories, priceRanges },
+    };
+}
+
+module.exports = {
+    PRICE_RANGES,
+    getBlackFridayProducts,
+};

--- a/backend/src/services/products.service.js
+++ b/backend/src/services/products.service.js
@@ -25,48 +25,6 @@ function getFeaturedProducts({ limit = 8, alexaMinimum = 2 } = {}) {
     return [...guaranteed, ...fillers];
 }
 
-const PRICE_RANGES = {
-    'all': null,
-    '0-50': [0, 50],
-    '50-100': [50, 100],
-    '100-300': [100, 300],
-    '300-999': [300, 999],
-};
-
-function getBlackFridayProducts({ category, priceRange, minRating } = {}) {
-    const base = repo.findBlackFriday();
-
-    let filtered = base;
-
-    if (category) {
-        const normalized = category.trim().toLowerCase();
-        filtered = filtered.filter(
-            (p) => p.category && p.category.toLowerCase().includes(normalized)
-        );
-    }
-
-    if (priceRange && priceRange !== 'all') {
-        const range = PRICE_RANGES[priceRange];
-        if (range) {
-            const [min, max] = range;
-            filtered = filtered.filter((p) => p.price >= min && p.price <= max);
-        }
-    }
-
-    if (minRating !== undefined && minRating !== null && !Number.isNaN(Number(minRating))) {
-        const min = Number(minRating);
-        filtered = filtered.filter((p) => (p.rating || 0) >= min);
-    }
-
-    const categories = [...new Set(base.map((p) => p.category).filter(Boolean))];
-    const priceRanges = Object.keys(PRICE_RANGES).filter((k) => k !== 'all');
-
-    return {
-        products: filtered,
-        filters: { categories, priceRanges },
-    };
-}
-
 function getRecommendations(cartItemIds, { perCategoryLimit = 10 } = {}) {
     if (!Array.isArray(cartItemIds) || cartItemIds.length === 0) {
         return [];
@@ -120,7 +78,6 @@ module.exports = {
     getProductById,
     searchProducts,
     getFeaturedProducts,
-    getBlackFridayProducts,
     getRecommendations,
     createProduct,
     updateProduct,

--- a/backend/test/blackFriday.split.test.js
+++ b/backend/test/blackFriday.split.test.js
@@ -1,0 +1,78 @@
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+// Isola o banco antes de qualquer modulo carregar o singleton de conexao.
+// Define DB_PATH e DATABASE_PATH para funcionar independente da nomenclatura.
+const TEST_DB = path.join(os.tmpdir(), `bulbe-bf-test-${process.pid}-${Date.now()}.db`);
+process.env.DB_PATH = TEST_DB;
+process.env.DATABASE_PATH = TEST_DB;
+
+// Migrations + seed antes de carregar os apps, pois os repositorios preparam
+// statements no momento do require. O seed marca os ids 1, 3, 4 e 6 como
+// black_friday, garantindo lista nao vazia.
+require('../src/db/migrate').runMigrations();
+require('../src/db/seeds/seed_products');
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const blackFridayApp = require('../src/blackFridayApp');
+const mainApp = require('../src/app');
+
+const BF_PATH = '/api/v1/products/black-friday';
+
+test.after(() => {
+    for (const suffix of ['', '-wal', '-shm', '-journal']) {
+        fs.rmSync(TEST_DB + suffix, { force: true });
+    }
+});
+
+test('app dedicado responde 200 na black-friday com produtos e filtros', async () => {
+    const res = await request(blackFridayApp).get(BF_PATH);
+
+    assert.equal(res.status, 200);
+    assert.ok(Array.isArray(res.body.products), 'products deve ser array');
+    assert.ok(res.body.products.length > 0, 'seed marca ids 1,3,4,6 como black_friday');
+    assert.equal(res.body.total, res.body.products.length);
+    assert.ok(Array.isArray(res.body.filters.categories), 'filters.categories deve ser array');
+    assert.ok(Array.isArray(res.body.filters.priceRanges), 'filters.priceRanges deve ser array');
+});
+
+test('app dedicado rejeita priceRange invalido com 400', async () => {
+    const res = await request(blackFridayApp).get(BF_PATH).query({ priceRange: 'banana' });
+
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error, 'priceRange invalido');
+});
+
+test('app dedicado aplica o filtro de priceRange valido', async () => {
+    const res = await request(blackFridayApp).get(BF_PATH).query({ priceRange: '300-999' });
+
+    assert.equal(res.status, 200);
+    for (const p of res.body.products) {
+        assert.ok(p.price >= 300 && p.price <= 999, `preco ${p.price} fora da faixa 300-999`);
+    }
+});
+
+test('app principal NAO serve mais a black-friday (cai em /:id e retorna 404)', async () => {
+    const res = await request(mainApp).get(BF_PATH);
+
+    assert.equal(res.status, 404);
+    assert.equal(res.body.error, 'Produto nao encontrado');
+});
+
+test('app principal continua servindo catalogo, destaques e produto por id', async () => {
+    const list = await request(mainApp).get('/api/v1/products');
+    assert.equal(list.status, 200);
+    assert.ok(Array.isArray(list.body.products));
+
+    const featured = await request(mainApp).get('/api/v1/products/featured');
+    assert.equal(featured.status, 200);
+    assert.ok(Array.isArray(featured.body.products));
+
+    const byId = await request(mainApp).get('/api/v1/products/1');
+    assert.equal(byId.status, 200);
+    assert.equal(byId.body.id, 1);
+});

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -8,6 +8,10 @@
  * BASE_URL pode ser sobrescrita antes do load via:
  *   window.__BULBE_API_BASE_URL__ = 'http://x.y/api/v1'
  *
+ * A black-friday roda num servico isolado, em porta dedicada. Sua base e a
+ * BLACK_FRIDAY_BASE_URL (sobrescrivivel via window.__BULBE_BF_API_BASE_URL__);
+ * passe `{ baseUrl: Api.BLACK_FRIDAY_BASE_URL }` na chamada para mira-la.
+ *
  * Sessao guest (US-27): `ensureSession()` chama `POST /users` quando nao ha
  * token salvo e persiste `token`/`userId` no localStorage (`authToken`/`userId`).
  * O middleware do backend trata qualquer Bearer nao vazio como `userId`, logo
@@ -15,6 +19,8 @@
  */
 const Api = (function () {
     const BASE_URL = window.__BULBE_API_BASE_URL__ || 'http://localhost:3001/api/v1';
+    // Servico isolado da Black Friday (bulkhead): porta propria, base propria.
+    const BLACK_FRIDAY_BASE_URL = window.__BULBE_BF_API_BASE_URL__ || 'http://localhost:3002/api/v1';
 
     const TOKEN_KEY = 'authToken';
     const USER_KEY = 'userId';
@@ -75,7 +81,8 @@ const Api = (function () {
 
     async function request(method, path, options) {
         const opts = options || {};
-        const url = BASE_URL + path + buildQuery(opts.query);
+        const base = opts.baseUrl || BASE_URL;
+        const url = base + path + buildQuery(opts.query);
         const headers = { Accept: 'application/json' };
         if (opts.body !== undefined) headers['Content-Type'] = 'application/json';
         if (opts.auth) headers['Authorization'] = `Bearer ${await ensureSession()}`;
@@ -109,6 +116,7 @@ const Api = (function () {
 
     return {
         BASE_URL,
+        BLACK_FRIDAY_BASE_URL,
         getToken,
         setSession,
         getUserId,

--- a/frontend/js/black-friday.js
+++ b/frontend/js/black-friday.js
@@ -29,6 +29,7 @@ async function fetchAndRenderBlackFriday() {
 
     try {
         const data = await Api.get('/products/black-friday', {
+            baseUrl: Api.BLACK_FRIDAY_BASE_URL,
             query: {
                 category: serverCategory,
                 priceRange,


### PR DESCRIPTION
## Resumo

Separa os endpoints da **Black Friday** num serviço próprio, rodando numa
**porta dedicada** (`BLACK_FRIDAY_PORT`, padrão `3002`), independente da API
principal (`PORT`, padrão `3001`). O app principal deixa de servir a rota da
campanha; quem responde por ela agora é o `blackFridayApp`/`blackFridayServer`.

A entrega vem em commits granulados, cada um num passo coerente:

1. `refactor` — extrai a black-friday de `products.*` para um módulo dedicado (sem mudar comportamento, o app principal ainda serve a rota).
2. `feat` — adiciona `blackFridayApp.js`, `blackFridayServer.js`, scripts npm e a var de ambiente.
3. `feat` — remove a black-friday do app principal, isolando-a de fato.
4. `test` — cobre o isolamento (app dedicado serve; principal dá 404; resto intacto).
5. `feat(fe)` — a página de black-friday passa a falar com a porta dedicada.
6. `docs` — openapi (`servers`) + README com o passo a passo dos dois serviços.

## Por que uma porta separada (padrão *bulkhead*)

A Black Friday é o pico de tráfego do ano. Com tudo no mesmo processo Node (mesmo
event loop), uma enxurrada de requisições na campanha pode saturar o servidor e
**derrubar junto o catálogo, o carrinho e o checkout** — exatamente o fluxo que
está vendendo. Num processo próprio, numa porta própria, a campanha ganha:

- **Domínio de falha isolado:** se a black-friday travar, só ela reinicia.
- **Escala/deploy/rate-limit/cache independentes:** a lista de promoções é
  altamente cacheável, ao contrário do carrinho (que é por usuário).
- **Observabilidade separada:** métricas e logs da campanha por conta própria.

Numa porta no mesmo host isso é isolamento de **processo** (CPU e SQLite seguem
compartilhados); o ganho de hardware vem depois, mas a costura arquitetural que
permite mover a campanha pra outra máquina/réplica já fica pronta aqui.

## Contrato

- A rota pública **não muda de path**: continua `GET /api/v1/products/black-friday`,
  só muda o **host:porta** (passa a `:3002`).
- No app principal, essa rota agora cai em `/products/:id` e devolve `404`
  "Produto nao encontrado" de forma limpa.
- O front consome a campanha via `Api.BLACK_FRIDAY_BASE_URL`
  (sobrescrivível por `window.__BULBE_BF_API_BASE_URL__`); o resto segue na `:3001`.

## Critérios de aceitação

- [x] `GET /api/v1/products/black-friday` responde no serviço dedicado (`:3002`) com produtos + filtros
- [x] Filtros `category` / `priceRange` / `minRating` preservados (mesma lógica de antes)
- [x] `priceRange` inválido retorna `400`
- [x] App principal **não** serve mais a black-friday (retorna `404`)
- [x] App principal segue servindo catálogo, busca, destaques, recomendações e `/products/:id`
- [x] Front (página black-friday) aponta para a porta dedicada
- [x] OpenAPI e README documentam a separação

## Test plan

- [x] `npm test` — 12/12 passam (7 de auth + 5 do novo `blackFriday.split.test.js`)
- [x] Smoke: `npm run start:blackfriday` sobe em `:3002` e o endpoint responde `200`
- [x] Smoke: app principal devolve `404` na rota da campanha e `200` no catálogo/destaques
- [x] CORS: servidor da black-friday emite `Access-Control-Allow-Origin: *` (fetch cross-origin do front OK)
- [ ] **Visual (recomendado ao revisar):** abrir `black-friday.html` com as duas APIs no ar e conferir a grade de produtos renderizando

> Sem issue vinculada: é uma melhoria de arquitetura (isolamento de carga), não uma US do backlog.